### PR TITLE
VPP-287: Use rubocop enablement to fix multiple small bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Gemfile.lock
 *./DS_Store
 
 *.log
+
+# RSpec failure tracker for --only-failures and --next-failure
+spec/examples.txt

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/NumericLiterals:
-  Enabled: false
 Style/PercentLiteralDelimiters:
   Enabled: false
 Style/RedundantSelf:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,8 +14,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Style/AndOr:
-  Enabled: false
 Style/BlockComments:
   Enabled: false
 Style/ClassAndModuleChildren:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,8 +22,6 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 Style/Documentation:
   Enabled: false
-Style/EmptyLinesAroundMethodBody:
-  Enabled: false
 Style/ExtraSpacing:
   Enabled: false
 Style/GuardClause:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ AllCops:
 
 Lint/Eval:
   Enabled: false
-Lint/HandleExceptions:
-  Enabled: false
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
 Lint/UnusedBlockArgument:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,8 +22,6 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 Style/Documentation:
   Enabled: false
-Style/GuardClause:
-  Enabled: false
 Style/IfInsideElse:
   Enabled: false
 Style/IfUnlessModifier:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,10 @@ Style/IfUnlessModifier:
                  the line cannot tell you if the body is ever executed.
   Enabled: false
 Style/StringLiterals:
-  Enabled: false
+  Description: >-
+                 Double quotes work for Strings in both Ruby and Elixir, so developers switch languages can use
+                 consistent quoting. (Single quotes are char lists in Elixir.)
+  EnforcedStyle: double_quotes
 Style/SymbolProc:
   Enabled: false
 Style/TrivialAccessors:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,8 +14,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Style/AlignHash:
-  Enabled: false
 Style/AlignParameters:
   Enabled: false
 Style/AndOr:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,8 +20,6 @@ Style/ClassAndModuleChildren:
                  module.  Reopening the parent class or module can lead to the parent class or module not being loaded
                  as the child already defined it.
   EnforcedStyle: compact
-Style/ConditionalAssignment:
-  Enabled: false
 Style/Documentation:
   Enabled: false
 Style/EmptyLines:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,8 +14,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Style/BlockComments:
-  Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/ConditionalAssignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,5 +37,3 @@ Style/WhileUntilModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/WordArray:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ AllCops:
 
 Lint/Eval:
   Enabled: false
-Lint/UselessAssignment:
-  Enabled: false
 
 Metrics/AbcSize:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,8 +20,6 @@ Style/ClassAndModuleChildren:
                  module.  Reopening the parent class or module can lead to the parent class or module not being loaded
                  as the child already defined it.
   EnforcedStyle: compact
-Style/Documentation:
-  Enabled: false
 Style/IfUnlessModifier:
   Description: >-
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,18 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/SpaceAroundOperators:
-  Enabled: false
-Style/SpaceBeforeBlockBraces:
-  Enabled: false
-Style/SpaceBeforeComma:
-  Enabled: false
-Style/SpaceInsideBlockBraces:
-  Enabled: false
-Style/SpaceInsideHashLiteralBraces:
-  Enabled: false
-Style/SpaceInsideParens:
-  Enabled: false
 Style/SpecialGlobalVars:
   Enabled: false
 Style/StringLiterals:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,8 +9,6 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/LineLength:
   Max: 120
-Metrics/MethodLength:
-  Enabled: false
 
 Style/ClassAndModuleChildren:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/RegexpLiteral:
-  Enabled: false
 Style/Semicolon:
   Enabled: false
 Style/SpaceAroundOperators:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,8 +14,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Style/AccessorMethodName:
-  Enabled: false
 Style/AlignHash:
   Enabled: false
 Style/AlignParameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,6 @@ Style/StringLiterals:
                  Double quotes work for Strings in both Ruby and Elixir, so developers switch languages can use
                  consistent quoting. (Single quotes are char lists in Elixir.)
   EnforcedStyle: double_quotes
-Style/UnneededInterpolation:
-  Enabled: false
 Style/UnneededPercentQ:
   Enabled: false
 Style/WhileUntilModifier:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ AllCops:
 
 Lint/Eval:
   Enabled: false
-Lint/ShadowingOuterLocalVariable:
-  Enabled: false
 Lint/UnusedBlockArgument:
   Enabled: false
 Lint/UselessAssignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,6 @@ Style/StringLiterals:
                  Double quotes work for Strings in both Ruby and Elixir, so developers switch languages can use
                  consistent quoting. (Single quotes are char lists in Elixir.)
   EnforcedStyle: double_quotes
-Style/SymbolProc:
-  Enabled: false
 Style/TrivialAccessors:
   Enabled: false
 Style/UnneededInterpolation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/RedundantSelf:
-  Enabled: false
 Style/RegexpLiteral:
   Enabled: false
 Style/Semicolon:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/Semicolon:
-  Enabled: false
 Style/SpaceAroundOperators:
   Enabled: false
 Style/SpaceBeforeBlockBraces:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/MutableConstant:
-  Enabled: false
 Style/NegatedWhile:
   Enabled: false
 Style/NumericLiterals:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,8 +14,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Style/AlignParameters:
-  Enabled: false
 Style/AndOr:
   Enabled: false
 Style/BlockComments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,6 @@ Style/StringLiterals:
                  Double quotes work for Strings in both Ruby and Elixir, so developers switch languages can use
                  consistent quoting. (Single quotes are char lists in Elixir.)
   EnforcedStyle: double_quotes
-Style/UnneededPercentQ:
-  Enabled: false
 Style/WhileUntilModifier:
   Enabled: false
 Style/WordArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,6 @@ AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.2
 
-Lint/DeprecatedClassMethods:
-  Enabled: false
 Lint/Eval:
   Enabled: false
 Lint/HandleExceptions:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,6 @@ AllCops:
 Lint/Eval:
   Enabled: false
 
-Metrics/ClassLength:
-  Enabled: false
 Metrics/LineLength:
   Max: 120
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ AllCops:
 
 Lint/Eval:
   Enabled: false
-Lint/UnusedBlockArgument:
-  Enabled: false
 Lint/UselessAssignment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,6 @@ Style/StringLiterals:
                  Double quotes work for Strings in both Ruby and Elixir, so developers switch languages can use
                  consistent quoting. (Single quotes are char lists in Elixir.)
   EnforcedStyle: double_quotes
-Style/TrivialAccessors:
-  Enabled: false
 Style/UnneededInterpolation:
   Enabled: false
 Style/UnneededPercentQ:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,8 +22,6 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 Style/Documentation:
   Enabled: false
-Style/IfInsideElse:
-  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
 Style/IndentationConsistency:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,6 @@ AllCops:
 Lint/Eval:
   Enabled: false
 
-Metrics/AbcSize:
-  Enabled: false
 Metrics/ClassLength:
   Enabled: false
 Metrics/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,6 @@ AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.2
 
-Lint/Eval:
-  Enabled: false
-
 Metrics/LineLength:
   Max: 120
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Enabled: false
 Metrics/LineLength:
-  Enabled: false
+  Max: 120
 Metrics/MethodLength:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Style/StringLiterals:
                  consistent quoting. (Single quotes are char lists in Elixir.)
   EnforcedStyle: double_quotes
 Style/WhileUntilModifier:
+  Description: >-
+                 Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
+                 the line cannot tell you if the body is ever executed.
   Enabled: false
 Style/WordArray:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/SpecialGlobalVars:
-  Enabled: false
 Style/StringLiterals:
   Enabled: false
 Style/SymbolProc:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Performance/Detect:
-  Enabled: false
-
 Style/AccessorMethodName:
   Enabled: false
 Style/AlignHash:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,8 +22,6 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 Style/Documentation:
   Enabled: false
-Style/EmptyLines:
-  Enabled: false
 Style/EmptyLinesAroundMethodBody:
   Enabled: false
 Style/ExtraSpacing:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,11 @@ Style/ClassAndModuleChildren:
                  module.  Reopening the parent class or module can lead to the parent class or module not being loaded
                  as the child already defined it.
   EnforcedStyle: compact
+Style/GuardClause:
+  Description: >-
+                 Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
+                 the line cannot tell you if the body is ever executed.
+  Enabled: false
 Style/IfUnlessModifier:
   Description: >-
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,8 @@ Metrics/ClassLength:
 Metrics/LineLength:
   Max: 120
 
+Style/BlockDelimiters:
+  EnforcedStyle: semantic
 Style/ClassAndModuleChildren:
   Description: >-
                  Compact style ensures that the parent classes and modules are not reopened for each child class and

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/PercentLiteralDelimiters:
-  Enabled: false
 Style/RedundantSelf:
   Enabled: false
 Style/RegexpLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,14 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/IndentationConsistency:
-  Enabled: false
-Style/IndentationWidth:
-  Enabled: false
-Style/IndentHash:
-  Enabled: false
-Style/MultilineMethodCallIndentation:
-  Enabled: false
 Style/MutableConstant:
   Enabled: false
 Style/NegatedWhile:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,107 @@
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.2
+
+Lint/DeprecatedClassMethods:
+  Enabled: false
+Lint/Eval:
+  Enabled: false
+Lint/HandleExceptions:
+  Enabled: false
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+Lint/UnusedBlockArgument:
+  Enabled: false
+Lint/UselessAssignment:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+
+Performance/Detect:
+  Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false
+Style/AlignHash:
+  Enabled: false
+Style/AlignParameters:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/BlockComments:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/EmptyLines:
+  Enabled: false
+Style/EmptyLinesAroundMethodBody:
+  Enabled: false
+Style/ExtraSpacing:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/IndentationConsistency:
+  Enabled: false
+Style/IndentationWidth:
+  Enabled: false
+Style/IndentHash:
+  Enabled: false
+Style/MultilineMethodCallIndentation:
+  Enabled: false
+Style/MutableConstant:
+  Enabled: false
+Style/NegatedWhile:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/Semicolon:
+  Enabled: false
+Style/SpaceAroundOperators:
+  Enabled: false
+Style/SpaceBeforeBlockBraces:
+  Enabled: false
+Style/SpaceBeforeComma:
+  Enabled: false
+Style/SpaceInsideBlockBraces:
+  Enabled: false
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Style/SpaceInsideParens:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false
+Style/UnneededInterpolation:
+  Enabled: false
+Style/UnneededPercentQ:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,8 +27,6 @@ Style/IfUnlessModifier:
                  Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
                  the line cannot tell you if the body is ever executed.
   Enabled: false
-Style/NegatedWhile:
-  Enabled: false
 Style/NumericLiterals:
   Enabled: false
 Style/PercentLiteralDelimiters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,11 @@ Metrics/MethodLength:
   Enabled: false
 
 Style/ClassAndModuleChildren:
-  Enabled: false
+  Description: >-
+                 Compact style ensures that the parent classes and modules are not reopened for each child class and
+                 module.  Reopening the parent class or module can lead to the parent class or module not being loaded
+                 as the child already defined it.
+  EnforcedStyle: compact
 Style/ConditionalAssignment:
   Enabled: false
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 Style/IfUnlessModifier:
+  Description: >-
+                 Modifiers prevent placing break points on just the condition or just the body.  Similarly, coverage of
+                 the line cannot tell you if the body is ever executed.
   Enabled: false
 Style/IndentationConsistency:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,8 +22,6 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 Style/Documentation:
   Enabled: false
-Style/ExtraSpacing:
-  Enabled: false
 Style/GuardClause:
   Enabled: false
 Style/IfInsideElse:

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ ruby "2.2.3"
 # Specify your gem's dependencies in carrot_rpc.gemspec
 gemspec
 
-gem "bunny", "~> 2.2"
-
 group :test do
   gem 'rspec_junit_formatter', '0.2.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby "2.2.3"
 # Specify your gem's dependencies in carrot_rpc.gemspec
 gemspec
 
 group :test do
-  gem 'rspec_junit_formatter', '0.2.2'
+  gem "rspec_junit_formatter", "0.2.2"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/bin/carrot_rpc
+++ b/bin/carrot_rpc
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'bunny'
-require_relative '../lib/carrot_rpc'
-require_relative '../lib/carrot_rpc/cli'
-require_relative '../lib/carrot_rpc/server_runner'
+require "bunny"
+require_relative "../lib/carrot_rpc"
+require_relative "../lib/carrot_rpc/cli"
+require_relative "../lib/carrot_rpc/server_runner"
 
 CarrotRpc::CLI.parse_options(ARGV)
 

--- a/bin/console
+++ b/bin/console
@@ -13,6 +13,7 @@ require "carrot_rpc"
 begin
   require "byebug"
 rescue LoadError
+  $stderr.puts "byebug could not be loaded"
 end
 
 require "irb"

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -6,8 +6,8 @@ require "carrot_rpc/version"
 Gem::Specification.new do |spec|
   spec.name          = "carrot_rpc"
   spec.version       = CarrotRpc::VERSION
-  spec.authors       = ["Scott Hamilton"]
-  spec.email         = ["shamil614@gmail.com"]
+  spec.authors       = ["Scott Hamilton", "Luke Imhoff"]
+  spec.email         = ["shamil614@gmail.com", "Kronic.Deth@gmail.com"]
 
   spec.summary       = "Remote Procedure Call (RPC) using the Bunny Gem over RabbitMQ"
   spec.description   = "Streamlined approach to setting up RPC over RabbitMQ."

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Remote Procedure Call (RPC) using the Bunny Gem over RabbitMQ"
   spec.description   = "Streamlined approach to setting up RPC over RabbitMQ."
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/C-S-D/carrot_rpc"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
+  unless spec.respond_to?(:metadata)
     fail "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
+
+  spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Scott Hamilton"]
   spec.email         = ["shamil614@gmail.com"]
 
-  spec.summary       = %q{Remote Procedure Call (RPC) using the Bunny Gem over RabbitMQ}
-  spec.description   = %q(Streamlined approach to setting up RPC over RabbitMQ.)
+  spec.summary       = "Remote Procedure Call (RPC) using the Bunny Gem over RabbitMQ"
+  spec.description   = "Streamlined approach to setting up RPC over RabbitMQ."
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["shamil614@gmail.com"]
 
   spec.summary       = %q{Remote Procedure Call (RPC) using the Bunny Gem over RabbitMQ}
-  spec.description   = %q{Streamlined approach to setting up RPC over RabbitMQ.}
+  spec.description   = %q(Streamlined approach to setting up RPC over RabbitMQ.)
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'carrot_rpc/version'
+require "carrot_rpc/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "carrot_rpc"
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     fail "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
   else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+    fail "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -28,13 +28,22 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Production requirements
-  spec.add_dependency "bunny", "~> 2.2"
+
+  # Common extensions from Rails
   spec.add_dependency "activesupport", "~> 4.2"
-  spec.required_ruby_version = "~> 2.2"
+  # The RabbitMQ library
+  spec.add_dependency "bunny", "~> 2.2"
 
   # Development / Test Gems
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+
+  # debugger
   spec.add_development_dependency "byebug"
+  # Gemfile support for grouping gems for development-only or test-only
+  spec.add_development_dependency "bundler", "~> 1.9"
+  # Running commandline scripts
+  spec.add_development_dependency "rake", "~> 10.0"
+  # Unit test framework
+  spec.add_development_dependency "rspec"
+
+  spec.required_ruby_version = "~> 2.2"
 end

--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -44,6 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   # Unit test framework
   spec.add_development_dependency "rspec"
+  # Style-checker
+  spec.add_development_dependency "rubocop"
 
   spec.required_ruby_version = "~> 2.2"
 end

--- a/circle.yml
+++ b/circle.yml
@@ -4,3 +4,5 @@ machine:
 test:
   override:
     - RAILS_ENV=test bundle exec rspec -r rspec_junit_formatter --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+  post:
+    - bundle exec rubocop

--- a/lib/carrot_rpc.rb
+++ b/lib/carrot_rpc.rb
@@ -1,15 +1,28 @@
-require "carrot_rpc/version"
+# gem dependencies
+require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/hash/except"
+require "active_support/dependencies/autoload"
 require "bunny"
-require "carrot_rpc/cli"
-require "carrot_rpc/configuration"
-require "carrot_rpc/tagged_log"
-require "carrot_rpc/rpc_client"
-require "carrot_rpc/rpc_server"
-require 'active_support/core_ext/hash/indifferent_access'
-require 'active_support/core_ext/hash/except'
-require 'json'
+
+# standard library
+require "json"
+require "optparse"
+
+# project
+require "carrot_rpc/version"
 
 module CarrotRpc
+  extend ActiveSupport::Autoload
+
+  autoload :CLI
+  autoload :ClientServer
+  autoload :Configuration
+  autoload :HashExtensions
+  autoload :RpcClient
+  autoload :RpcServer
+  autoload :ServerRunner
+  autoload :TaggedLog
+
   class << self
     attr_writer :configuration
   end

--- a/lib/carrot_rpc.rb
+++ b/lib/carrot_rpc.rb
@@ -11,6 +11,9 @@ require "optparse"
 # project
 require "carrot_rpc/version"
 
+# An opinionated approach to doing Remote Procedure Call (RPC) with RabbitMQ and the bunny gem. CarrotRpc serves as a
+# way to streamline the RPC workflow so developers can focus on the implementation and not the plumbing when working
+# with RabbitMQ.
 module CarrotRpc
   extend ActiveSupport::Autoload
 

--- a/lib/carrot_rpc/.#rpc_server.rb
+++ b/lib/carrot_rpc/.#rpc_server.rb
@@ -1,1 +1,0 @@
-shamilton@MAC-SHAMILTON.local.17639

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -1,5 +1,3 @@
-require 'bunny'
-require 'optparse'
 
 class CarrotRpc::CLI
   # Class methods

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -1,4 +1,4 @@
-
+# Command-line interface for {CarrotRpc}
 class CarrotRpc::CLI
   # Class methods
   class << self

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -70,8 +70,6 @@ module CarrotRpc::CLI
     end
   end
 
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-
   def self.add_ruby_options(option_parser)
     option_parser.separator ""
 
@@ -81,9 +79,16 @@ module CarrotRpc::CLI
       $LOAD_PATH.unshift(*value.split(":").map { |v| File.expand_path(v) })
     end
 
-    option_parser.on("--debug", "set $DEBUG to true") { $DEBUG = true }
-    option_parser.on("--warn", "enable warnings") { $-w = true }
+    option_parser.on("--debug", "set $DEBUG to true") do
+      $DEBUG = true
+    end
+
+    option_parser.on("--warn", "enable warnings") do
+      $-w = true
+    end
   end
+
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def self.option_parser
     option_parser = OptionParser.new

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -64,7 +64,9 @@ module CarrotRpc
         op.separator ""
 
         op.separator "Ruby options:"
-        op.on("-I", "--include PATH", include_help) { |value| $LOAD_PATH.unshift(*value.split(":").map{|v| File.expand_path(v)}) }
+        op.on("-I", "--include PATH", include_help) do |value|
+          $LOAD_PATH.unshift(*value.split(":").map{|v| File.expand_path(v)})
+        end
         op.on(      "--debug",        debug_help)   { $DEBUG = true }
         op.on(      "--warn",         warn_help)    { $-w = true    }
         op.separator ""

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -2,10 +2,6 @@
 class CarrotRpc::CLI
   # Class methods
   class << self
-    def self.run!(argv = ARGV)
-      parse_options(argv)
-    end
-
     def parse_options(args = ARGV)
       # Set defaults below.
       version             = "1.0.0"

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -11,7 +11,6 @@ module CarrotRpc
 
       def parse_options(args = ARGV)
         # Set defaults below.
-        options             = { }
         version             = "1.0.0"
         daemonize_help      = "run daemonized in the background (default: false)"
         runloop_sleep_help  = "Configurable sleep time in the runloop"

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -27,7 +27,7 @@ class CarrotRpc::CLI
       op.separator ""
 
       op.separator "Process options:"
-      op.on("-d", "--daemonize",   daemonize_help) do
+      op.on("-d", "--daemonize", daemonize_help) do
         CarrotRpc.configuration.daemonize = true
       end
 
@@ -35,7 +35,7 @@ class CarrotRpc::CLI
         CarrotRpc.configuration.pidfile = value
       end
 
-      op.on("-s", "--runloop_sleep VALUE", Float, runloop_sleep_help)  do |value|
+      op.on("-s", "--runloop_sleep VALUE", Float, runloop_sleep_help) do |value|
         CarrotRpc.configuration.runloop_sleep = value
       end
 

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -69,8 +69,14 @@ class CarrotRpc::CLI
       op.separator ""
 
       op.separator "Common options:"
-      op.on("-h", "--help")    { puts op.to_s; exit }
-      op.on("-v", "--version") { puts version; exit }
+      op.on("-h", "--help") do
+        puts op.to_s
+        exit
+      end
+      op.on("-v", "--version") do
+        puts version
+        exit
+      end
       op.separator ""
       op.parse!(args)
     end

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -1,82 +1,80 @@
 require 'bunny'
 require 'optparse'
 
-module CarrotRpc
-  class CLI
-    # Class methods
-    class << self
-      def self.run!(argv = ARGV)
-        parse_options(argv)
+class CarrotRpc::CLI
+  # Class methods
+  class << self
+    def self.run!(argv = ARGV)
+      parse_options(argv)
+    end
+
+    def parse_options(args = ARGV)
+      # Set defaults below.
+      version             = "1.0.0"
+      daemonize_help      = "run daemonized in the background (default: false)"
+      runloop_sleep_help  = "Configurable sleep time in the runloop"
+      pidfile_help        = "the pid filename"
+      include_help        = "an additional $LOAD_PATH"
+      debug_help          = "set $DEBUG to true"
+      warn_help           = "enable warnings"
+      autoload_rails_help = "loads rails env by default. Uses Rails Logger by default."
+      logfile_help        = "relative path and name for Log file. Overrides Rails logger."
+      loglevel_help       = "levels of loggin: DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN"
+      rabbitmq_url_help   = "connection string to RabbitMQ 'amqp://user:pass@host:10000/vhost'"
+
+      op = OptionParser.new
+      op.banner =  "RPC Server Runner for RabbitMQ RPC Services."
+      op.separator ""
+      op.separator "Usage: server [options]"
+      op.separator ""
+
+      op.separator "Process options:"
+      op.on("-d", "--daemonize",   daemonize_help) do
+        CarrotRpc.configuration.daemonize = true
       end
 
-      def parse_options(args = ARGV)
-        # Set defaults below.
-        version             = "1.0.0"
-        daemonize_help      = "run daemonized in the background (default: false)"
-        runloop_sleep_help  = "Configurable sleep time in the runloop"
-        pidfile_help        = "the pid filename"
-        include_help        = "an additional $LOAD_PATH"
-        debug_help          = "set $DEBUG to true"
-        warn_help           = "enable warnings"
-        autoload_rails_help = "loads rails env by default. Uses Rails Logger by default."
-        logfile_help        = "relative path and name for Log file. Overrides Rails logger."
-        loglevel_help       = "levels of loggin: DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN"
-        rabbitmq_url_help   = "connection string to RabbitMQ 'amqp://user:pass@host:10000/vhost'"
-
-        op = OptionParser.new
-        op.banner =  "RPC Server Runner for RabbitMQ RPC Services."
-        op.separator ""
-        op.separator "Usage: server [options]"
-        op.separator ""
-
-        op.separator "Process options:"
-        op.on("-d", "--daemonize",   daemonize_help) do
-          CarrotRpc.configuration.daemonize = true
-        end
-
-        op.on(" ", "--pidfile PIDFILE", pidfile_help) do |value|
-          CarrotRpc.configuration.pidfile = value
-        end
-
-        op.on("-s", "--runloop_sleep VALUE", Float, runloop_sleep_help)  do |value|
-          CarrotRpc.configuration.runloop_sleep = value
-        end
-
-        op.on(" ", "--autoload_rails value", autoload_rails_help) do |value|
-          pv = value == "false" ? false : true
-          CarrotRpc.configuration.autoload_rails = pv
-        end
-
-        op.on(" ", "--logfile VALUE", logfile_help) do |value|
-          CarrotRpc.configuration.logfile = File.expand_path("../../#{value}", __FILE__)
-        end
-
-        op.on(" ", "--loglevel VALUE", loglevel_help) do |value|
-          level = eval(["Logger", value].join("::")) || 0
-          CarrotRpc.configuration.loglevel = level
-        end
-
-        # Optional. Defaults to using the ENV['RABBITMQ_URL']
-        op.on(" ", "--rabbitmq_url VALUE", rabbitmq_url_help) do |value|
-          CarrotRpc.configuration.bunny = Bunny.new(value)
-        end
-
-        op.separator ""
-
-        op.separator "Ruby options:"
-        op.on("-I", "--include PATH", include_help) do |value|
-          $LOAD_PATH.unshift(*value.split(":").map{|v| File.expand_path(v)})
-        end
-        op.on(      "--debug",        debug_help)   { $DEBUG = true }
-        op.on(      "--warn",         warn_help)    { $-w = true    }
-        op.separator ""
-
-        op.separator "Common options:"
-        op.on("-h", "--help")    { puts op.to_s; exit }
-        op.on("-v", "--version") { puts version; exit }
-        op.separator ""
-        op.parse!(args)
+      op.on(" ", "--pidfile PIDFILE", pidfile_help) do |value|
+        CarrotRpc.configuration.pidfile = value
       end
+
+      op.on("-s", "--runloop_sleep VALUE", Float, runloop_sleep_help)  do |value|
+        CarrotRpc.configuration.runloop_sleep = value
+      end
+
+      op.on(" ", "--autoload_rails value", autoload_rails_help) do |value|
+        pv = value == "false" ? false : true
+        CarrotRpc.configuration.autoload_rails = pv
+      end
+
+      op.on(" ", "--logfile VALUE", logfile_help) do |value|
+        CarrotRpc.configuration.logfile = File.expand_path("../../#{value}", __FILE__)
+      end
+
+      op.on(" ", "--loglevel VALUE", loglevel_help) do |value|
+        level = eval(["Logger", value].join("::")) || 0
+        CarrotRpc.configuration.loglevel = level
+      end
+
+      # Optional. Defaults to using the ENV['RABBITMQ_URL']
+      op.on(" ", "--rabbitmq_url VALUE", rabbitmq_url_help) do |value|
+        CarrotRpc.configuration.bunny = Bunny.new(value)
+      end
+
+      op.separator ""
+
+      op.separator "Ruby options:"
+      op.on("-I", "--include PATH", include_help) do |value|
+        $LOAD_PATH.unshift(*value.split(":").map{|v| File.expand_path(v)})
+      end
+      op.on(      "--debug",        debug_help)   { $DEBUG = true }
+      op.on(      "--warn",         warn_help)    { $-w = true    }
+      op.separator ""
+
+      op.separator "Common options:"
+      op.on("-h", "--help")    { puts op.to_s; exit }
+      op.on("-v", "--version") { puts version; exit }
+      op.separator ""
+      op.parse!(args)
     end
   end
 end

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -62,10 +62,10 @@ class CarrotRpc::CLI
 
       op.separator "Ruby options:"
       op.on("-I", "--include PATH", include_help) do |value|
-        $LOAD_PATH.unshift(*value.split(":").map{|v| File.expand_path(v)})
+        $LOAD_PATH.unshift(*value.split(":").map { |v| File.expand_path(v) })
       end
-      op.on(      "--debug",        debug_help)   { $DEBUG = true }
-      op.on(      "--warn",         warn_help)    { $-w = true    }
+      op.on("--debug",        debug_help)   { $DEBUG = true }
+      op.on("--warn",         warn_help)    { $-w = true    }
       op.separator ""
 
       op.separator "Common options:"

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -1,80 +1,106 @@
 # Command-line interface for {CarrotRpc}
-class CarrotRpc::CLI
-  # Class methods
-  class << self
-    def parse_options(args = ARGV)
-      # Set defaults below.
-      version             = "1.0.0"
-      daemonize_help      = "run daemonized in the background (default: false)"
-      runloop_sleep_help  = "Configurable sleep time in the runloop"
-      pidfile_help        = "the pid filename"
-      include_help        = "an additional $LOAD_PATH"
-      debug_help          = "set $DEBUG to true"
-      warn_help           = "enable warnings"
-      autoload_rails_help = "loads rails env by default. Uses Rails Logger by default."
-      logfile_help        = "relative path and name for Log file. Overrides Rails logger."
-      loglevel_help       = "levels of loggin: DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN"
-      rabbitmq_url_help   = "connection string to RabbitMQ 'amqp://user:pass@host:10000/vhost'"
+module CarrotRpc::CLI
+  def self.add_common_options(option_parser)
+    option_parser.separator ""
 
-      op = OptionParser.new
-      op.banner =  "RPC Server Runner for RabbitMQ RPC Services."
-      op.separator ""
-      op.separator "Usage: server [options]"
-      op.separator ""
-
-      op.separator "Process options:"
-      op.on("-d", "--daemonize", daemonize_help) do
-        CarrotRpc.configuration.daemonize = true
-      end
-
-      op.on(" ", "--pidfile PIDFILE", pidfile_help) do |value|
-        CarrotRpc.configuration.pidfile = value
-      end
-
-      op.on("-s", "--runloop_sleep VALUE", Float, runloop_sleep_help) do |value|
-        CarrotRpc.configuration.runloop_sleep = value
-      end
-
-      op.on(" ", "--autoload_rails value", autoload_rails_help) do |value|
-        pv = value == "false" ? false : true
-        CarrotRpc.configuration.autoload_rails = pv
-      end
-
-      op.on(" ", "--logfile VALUE", logfile_help) do |value|
-        CarrotRpc.configuration.logfile = File.expand_path("../../#{value}", __FILE__)
-      end
-
-      op.on(" ", "--loglevel VALUE", loglevel_help) do |value|
-        level = eval(["Logger", value].join("::")) || 0
-        CarrotRpc.configuration.loglevel = level
-      end
-
-      # Optional. Defaults to using the ENV['RABBITMQ_URL']
-      op.on(" ", "--rabbitmq_url VALUE", rabbitmq_url_help) do |value|
-        CarrotRpc.configuration.bunny = Bunny.new(value)
-      end
-
-      op.separator ""
-
-      op.separator "Ruby options:"
-      op.on("-I", "--include PATH", include_help) do |value|
-        $LOAD_PATH.unshift(*value.split(":").map { |v| File.expand_path(v) })
-      end
-      op.on("--debug",        debug_help)   { $DEBUG = true }
-      op.on("--warn",         warn_help)    { $-w = true    }
-      op.separator ""
-
-      op.separator "Common options:"
-      op.on("-h", "--help") do
-        puts op.to_s
-        exit
-      end
-      op.on("-v", "--version") do
-        puts version
-        exit
-      end
-      op.separator ""
-      op.parse!(args)
+    option_parser.separator "Common options:"
+    option_parser.on("-h", "--help") do
+      puts option_parser.to_s
+      exit
     end
+
+    option_parser.on("-v", "--version") do
+      puts CarrotRpc::VERSION
+      exit
+    end
+  end
+
+  # There are just too many options in the Process options category and they can't really be broken down more
+  # rubocop:disable Metrics/AbcSize
+
+  # Add "Process options" to `option_parser`.
+  #
+  # @param option_parser [OptionParser]
+  # @return [OptionParser]
+  def self.add_process_options(option_parser)
+    option_parser.separator ""
+
+    option_parser.separator "Process options:"
+    option_parser.on("-d", "--daemonize", "run daemonized in the background (default: false)") do
+      CarrotRpc.configuration.daemonize = true
+    end
+
+    option_parser.on(" ", "--pidfile PIDFILE", "the pid filename") do |value|
+      CarrotRpc.configuration.pidfile = value
+    end
+
+    option_parser.on("-s", "--runloop_sleep VALUE", Float, "Configurable sleep time in the runloop") do |value|
+      CarrotRpc.configuration.runloop_sleep = value
+    end
+
+    option_parser.on(
+      " ",
+      "--autoload_rails value",
+      "loads rails env by default. Uses Rails Logger by default."
+    ) do |value|
+      pv = value == "false" ? false : true
+      CarrotRpc.configuration.autoload_rails = pv
+    end
+
+    option_parser.on(" ", "--logfile VALUE", "relative path and name for Log file. Overrides Rails logger.") do |value|
+      CarrotRpc.configuration.logfile = File.expand_path("../../#{value}", __FILE__)
+    end
+
+    option_parser.on(
+      " ",
+      "--loglevel VALUE",
+      "levels of loggin: DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN"
+    ) do |value|
+      level                            = eval(["Logger", value].join("::")) || 0
+      CarrotRpc.configuration.loglevel = level
+    end
+
+    # Optional. Defaults to using the ENV['RABBITMQ_URL']
+    option_parser.on(
+      " ",
+      "--rabbitmq_url VALUE",
+      "connection string to RabbitMQ 'amqp://user:pass@host:10000/vhost'"
+    ) do |value|
+      CarrotRpc.configuration.bunny = Bunny.new(value)
+    end
+  end
+
+  # rubocop:enable Metrics/AbcSize
+
+  def self.add_ruby_options(option_parser)
+    option_parser.separator ""
+
+    option_parser.separator "Ruby options:"
+
+    option_parser.on("-I", "--include PATH", "an additional $LOAD_PATH") do |value|
+      $LOAD_PATH.unshift(*value.split(":").map { |v| File.expand_path(v) })
+    end
+
+    option_parser.on("--debug", "set $DEBUG to true") { $DEBUG = true }
+    option_parser.on("--warn", "enable warnings") { $-w = true }
+  end
+
+  def self.option_parser
+    option_parser = OptionParser.new
+    option_parser.banner =  "RPC Server Runner for RabbitMQ RPC Services."
+    option_parser.separator ""
+    option_parser.separator "Usage: server [options]"
+
+    add_process_options(option_parser)
+    add_ruby_options(option_parser)
+    add_common_options(option_parser)
+
+    option_parser.separator ""
+
+    option_parser
+  end
+
+  def self.parse_options(args = ARGV)
+    option_parser.parse!(args)
   end
 end

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -56,8 +56,7 @@ module CarrotRpc::CLI
       "--loglevel VALUE",
       "levels of loggin: DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN"
     ) do |value|
-      level                            = eval(["Logger", value].join("::")) || 0
-      CarrotRpc.configuration.loglevel = level
+      CarrotRpc.configuration.loglevel = Logger.const_get(value) || 0
     end
 
     # Optional. Defaults to using the ENV['RABBITMQ_URL']

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -16,7 +16,7 @@ module CarrotRpc::CLI
   end
 
   # There are just too many options in the Process options category and they can't really be broken down more
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 
   # Add "Process options" to `option_parser`.
   #
@@ -70,7 +70,7 @@ module CarrotRpc::CLI
     end
   end
 
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def self.add_ruby_options(option_parser)
     option_parser.separator ""

--- a/lib/carrot_rpc/client_server.rb
+++ b/lib/carrot_rpc/client_server.rb
@@ -1,5 +1,5 @@
 # Common functionality for Client and Server.
-module ClientServer
+module CarrotRpc::ClientServer
   # @overload queue_name(new_name)
   #   @note Default naming not performed. Class must pass queue name.
   #

--- a/lib/carrot_rpc/concerns/.#client_server.rb
+++ b/lib/carrot_rpc/concerns/.#client_server.rb
@@ -1,1 +1,0 @@
-shamilton@MAC-SHAMILTON.local.17639

--- a/lib/carrot_rpc/concerns/client_server.rb
+++ b/lib/carrot_rpc/concerns/client_server.rb
@@ -1,27 +1,25 @@
 # Common functionality for Client and Server.
 module ClientServer
-  module ClassMethods
-    # @overload queue_name(new_name)
-    #   @note Default naming not performed. Class must pass queue name.
-    #
-    #   Allows for class level definition of queue name.
-    #
-    #   @param new_name [String] the queue name for the class.
-    #   @return [String] `new_name`
-    #
-    # @overload queue_name
-    #   The current queue name previously set with `#queue_name(new_name)`.
-    #
-    #   @return [String]
-    def queue_name(*args)
-      if args.length == 0
-        @queue_name
-      elsif args.length == 1
-             @queue_name = args[0]
-      else
-        fail ArgumentError,
-             "queue_name(new_name) :: new_name or queue_name() :: current_name are the only ways to call queue_name"
-      end
+  # @overload queue_name(new_name)
+  #   @note Default naming not performed. Class must pass queue name.
+  #
+  #   Allows for class level definition of queue name.
+  #
+  #   @param new_name [String] the queue name for the class.
+  #   @return [String] `new_name`
+  #
+  # @overload queue_name
+  #   The current queue name previously set with `#queue_name(new_name)`.
+  #
+  #   @return [String]
+  def queue_name(*args)
+    if args.length == 0
+      @queue_name
+    elsif args.length == 1
+      @queue_name = args[0]
+    else
+      fail ArgumentError,
+           "queue_name(new_name) :: new_name or queue_name() :: current_name are the only ways to call queue_name"
     end
   end
 end

--- a/lib/carrot_rpc/concerns/client_server.rb
+++ b/lib/carrot_rpc/concerns/client_server.rb
@@ -1,14 +1,27 @@
 # Common functionality for Client and Server.
 module ClientServer
   module ClassMethods
-    # Allows for class level definition of queue name. Default naming not performed. Class must pass queue name.
-    def queue_name(name)
-      @queue_name = name
-    end
-
-    # Accessor for queue name.
-    def get_queue_name
-      @queue_name
+    # @overload queue_name(new_name)
+    #   @note Default naming not performed. Class must pass queue name.
+    #
+    #   Allows for class level definition of queue name.
+    #
+    #   @param new_name [String] the queue name for the class.
+    #   @return [String] `new_name`
+    #
+    # @overload queue_name
+    #   The current queue name previously set with `#queue_name(new_name)`.
+    #
+    #   @return [String]
+    def queue_name(*args)
+      if args.length == 0
+        @queue_name
+      elsif args.length == 1
+             @queue_name = args[0]
+      else
+        fail ArgumentError,
+          "queue_name(new_name) :: new_name or queue_name() :: current_name are the only ways to call queue_name"
+      end
     end
   end
 end

--- a/lib/carrot_rpc/concerns/client_server.rb
+++ b/lib/carrot_rpc/concerns/client_server.rb
@@ -20,7 +20,7 @@ module ClientServer
              @queue_name = args[0]
       else
         fail ArgumentError,
-          "queue_name(new_name) :: new_name or queue_name() :: current_name are the only ways to call queue_name"
+             "queue_name(new_name) :: new_name or queue_name() :: current_name are the only ways to call queue_name"
       end
     end
   end

--- a/lib/carrot_rpc/configuration.rb
+++ b/lib/carrot_rpc/configuration.rb
@@ -1,3 +1,4 @@
+# Global configuration for {CarrotRpc}.  Access with {CarrotRpc.configuration}.
 class CarrotRpc::Configuration
   attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :runloop_sleep, :autoload_rails, :bunny
 

--- a/lib/carrot_rpc/configuration.rb
+++ b/lib/carrot_rpc/configuration.rb
@@ -1,18 +1,16 @@
-module CarrotRpc
-  class Configuration
-      attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :runloop_sleep, :autoload_rails, :bunny
+class CarrotRpc::Configuration
+  attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :runloop_sleep, :autoload_rails, :bunny
 
-    # logfile - set logger to a file. overrides rails logger.
+  # logfile - set logger to a file. overrides rails logger.
 
-    def initialize
-      @logfile = nil
-      @loglevel = Logger::DEBUG
-      @logger = nil
-      @daemonize = false
-      @pidfile = nil
-      @runloop_sleep = 0
-      @autoload_rails = true
-      @bunny = nil
-    end
+  def initialize
+    @logfile = nil
+    @loglevel = Logger::DEBUG
+    @logger = nil
+    @daemonize = false
+    @pidfile = nil
+    @runloop_sleep = 0
+    @autoload_rails = true
+    @bunny = nil
   end
 end

--- a/lib/carrot_rpc/hash_extensions.rb
+++ b/lib/carrot_rpc/hash_extensions.rb
@@ -8,12 +8,14 @@ module CarrotRpc::HashExtensions
     def rename_keys(find, replace, new_hash = {})
       self.each do |k, v|
         new_key = k.gsub(find, replace)
-        if v.is_a? Hash
-          new_hash[new_key] = v.rename_keys(find, replace)
-        else
-          new_hash[new_key] = v
-        end
+
+        new_hash[new_key] = if v.is_a? Hash
+                              v.rename_keys(find, replace)
+                            else
+                              v
+                            end
       end
+
       new_hash
     end
   end

--- a/lib/carrot_rpc/hash_extensions.rb
+++ b/lib/carrot_rpc/hash_extensions.rb
@@ -1,5 +1,5 @@
-# Extend the Hash class with new methods and functionality.
-module HashExtensions
+# Refine the Hash class with new methods and functionality.
+module CarrotRpc::HashExtensions
   refine Hash do
     # Utility method to rename keys in a hash
     # @param [String] find the text to look for in a keys

--- a/lib/carrot_rpc/hash_extensions.rb
+++ b/lib/carrot_rpc/hash_extensions.rb
@@ -6,7 +6,7 @@ module CarrotRpc::HashExtensions
     # @param [String] replace the text to replace the found text
     # @return [Hash] a new hash
     def rename_keys(find, replace, new_hash = {})
-      self.each do |k, v|
+      each do |k, v|
         new_key = k.gsub(find, replace)
 
         new_hash[new_key] = if v.is_a? Hash

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -61,7 +61,7 @@ module CarrotRpc
       # Reply To => make sure the service knows where to send it's response.
       # Correlation ID => identify the results that belong to the unique call made
       @exchange.publish(message.to_json, routing_key: @server_queue.name, correlation_id: correlation_id,
-                        reply_to: @reply_queue.name)
+                                         reply_to: @reply_queue.name)
       result = @results[correlation_id].pop
       @results.delete correlation_id # remove item from hash. prevents memory leak.
       result

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -52,7 +52,12 @@ module CarrotRpc
     # @return [Object] the result of the method call.
     def remote_call(remote_method, params)
       correlation_id = SecureRandom.uuid
-      message = { id: correlation_id, jsonrpc: '2.0', method: remote_method, params: params.except(:controller, :action)}
+      message = {
+        id: correlation_id,
+        jsonrpc: '2.0',
+        method: remote_method,
+        params: params.except(:controller, :action)
+      }
       # Reply To => make sure the service knows where to send it's response.
       # Correlation ID => identify the results that belong to the unique call made
       @exchange.publish(message.to_json, routing_key: @server_queue.name, correlation_id: correlation_id,

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 # Generic class for all RPC Consumers. Use as a base class to build other RPC Consumers for related functionality.
 # Let's define a naming convention here for subclasses becuase I don't want to write a Confluence doc.
 # All subclasses should have the following naming convention: <Name>RpcConsumer  ex: PostRpcConsumer

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -33,7 +33,7 @@ class CarrotRpc::RpcClient
     # setup subscribe block to Service
     # block => false is a non blocking IO option.
     @reply_queue.subscribe(block: false) do |_delivery_info, properties, payload|
-      result = JSON.parse(payload).rename_keys('-', '_').with_indifferent_access
+      result = JSON.parse(payload).rename_keys("-", "_").with_indifferent_access
       @results[properties[:correlation_id]].push(result[:result])
     end
   end
@@ -50,7 +50,7 @@ class CarrotRpc::RpcClient
     correlation_id = SecureRandom.uuid
     message = {
       id: correlation_id,
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       method: remote_method,
       params: params.except(:controller, :action)
     }
@@ -68,7 +68,7 @@ class CarrotRpc::RpcClient
   #
   # @param params [Hash] the arguments for the method being called.
   def index(params)
-    remote_call('index', params)
+    remote_call("index", params)
   end
 
   # Convience method as a resource alias for show action.
@@ -76,7 +76,7 @@ class CarrotRpc::RpcClient
   #
   # @param params [Hash] the arguments for the method being called.
   def show(params)
-    remote_call('show', params)
+    remote_call("show", params)
   end
 
   # Convience method as a resource alias for create action.
@@ -84,7 +84,7 @@ class CarrotRpc::RpcClient
   #
   # @param params [Hash] the arguments for the method being called.
   def create(params)
-    remote_call('create', params)
+    remote_call("create", params)
   end
 
   # Convience method as a resource alias for update action.
@@ -92,6 +92,6 @@ class CarrotRpc::RpcClient
   #
   # @param params [Hash] the arguments for the method being called.
   def update(params)
-    remote_call('update', params)
+    remote_call("update", params)
   end
 end

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -19,7 +19,7 @@ module CarrotRpc
       @channel = config.bunny.create_channel
       @logger = config.logger
       # auto_delete => false keeps the queue around until RabbitMQ restarts or explicitly deleted
-      @server_queue  = @channel.queue(self.class.get_queue_name, auto_delete: false)
+      @server_queue  = @channel.queue(self.class.queue_name, auto_delete: false)
 
       # Setup a direct exchange.
       @exchange = @channel.default_exchange

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -1,15 +1,12 @@
-require "carrot_rpc/concerns/client_server"
-require "carrot_rpc/concerns/hash_extensions"
-
 # Generic class for all RPC Consumers. Use as a base class to build other RPC Consumers for related functionality.
 # Let's define a naming convention here for subclasses becuase I don't want to write a Confluence doc.
 # All subclasses should have the following naming convention: <Name>RpcConsumer  ex: PostRpcConsumer
 class CarrotRpc::RpcClient
-  using HashExtensions
+  using CarrotRpc::HashExtensions
 
   attr_reader :channel, :server_queue, :logger
 
-  extend ClientServer
+  extend CarrotRpc::ClientServer
 
   # Use defaults for application level connection to RabbitMQ
   # All RPC data goes over the same queue. I think that's ok....

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -36,7 +36,7 @@ module CarrotRpc
 
       # setup subscribe block to Service
       # block => false is a non blocking IO option.
-      @reply_queue.subscribe(block: false) do |delivery_info, properties, payload|
+      @reply_queue.subscribe(block: false) do |_delivery_info, properties, payload|
         result = JSON.parse(payload).rename_keys('-', '_').with_indifferent_access
         @results[properties[:correlation_id]].push(result[:result])
       end

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -28,7 +28,7 @@ class CarrotRpc::RpcClient
     @reply_queue = @channel.queue("", exclusive: true)
 
     # setup a hash for results with a Queue object as a value
-    @results = Hash.new{ |h, k| h[k] = Queue.new }
+    @results = Hash.new { |h, k| h[k] = Queue.new }
 
     # setup subscribe block to Service
     # block => false is a non blocking IO option.

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -15,7 +15,7 @@ class CarrotRpc::RpcClient
     @channel = config.bunny.create_channel
     @logger = config.logger
     # auto_delete => false keeps the queue around until RabbitMQ restarts or explicitly deleted
-    @server_queue  = @channel.queue(self.class.queue_name, auto_delete: false)
+    @server_queue = @channel.queue(self.class.queue_name, auto_delete: false)
 
     # Setup a direct exchange.
     @exchange = @channel.default_exchange

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -4,99 +4,97 @@ require "carrot_rpc/concerns/hash_extensions"
 # Generic class for all RPC Consumers. Use as a base class to build other RPC Consumers for related functionality.
 # Let's define a naming convention here for subclasses becuase I don't want to write a Confluence doc.
 # All subclasses should have the following naming convention: <Name>RpcConsumer  ex: PostRpcConsumer
-module CarrotRpc
-  class RpcClient
-    using HashExtensions
+class CarrotRpc::RpcClient
+  using HashExtensions
 
-    attr_reader :channel, :server_queue, :logger
+  attr_reader :channel, :server_queue, :logger
 
-    extend ClientServer::ClassMethods
+  extend ClientServer
 
-    # Use defaults for application level connection to RabbitMQ
-    # All RPC data goes over the same queue. I think that's ok....
-    def initialize(config: nil)
-      config ||= CarrotRpc.configuration
-      @channel = config.bunny.create_channel
-      @logger = config.logger
-      # auto_delete => false keeps the queue around until RabbitMQ restarts or explicitly deleted
-      @server_queue  = @channel.queue(self.class.queue_name, auto_delete: false)
+  # Use defaults for application level connection to RabbitMQ
+  # All RPC data goes over the same queue. I think that's ok....
+  def initialize(config: nil)
+    config ||= CarrotRpc.configuration
+    @channel = config.bunny.create_channel
+    @logger = config.logger
+    # auto_delete => false keeps the queue around until RabbitMQ restarts or explicitly deleted
+    @server_queue  = @channel.queue(self.class.queue_name, auto_delete: false)
 
-      # Setup a direct exchange.
-      @exchange = @channel.default_exchange
+    # Setup a direct exchange.
+    @exchange = @channel.default_exchange
+  end
+
+  # Starts the connection to listen for messages.
+  def start
+    # Empty queue name ends up creating a randomly named queue by RabbitMQ
+    # Exclusive => queue will be deleted when connection closes. Allows for automatic "cleanup".
+    @reply_queue = @channel.queue("", exclusive: true)
+
+    # setup a hash for results with a Queue object as a value
+    @results = Hash.new{ |h, k| h[k] = Queue.new }
+
+    # setup subscribe block to Service
+    # block => false is a non blocking IO option.
+    @reply_queue.subscribe(block: false) do |_delivery_info, properties, payload|
+      result = JSON.parse(payload).rename_keys('-', '_').with_indifferent_access
+      @results[properties[:correlation_id]].push(result[:result])
     end
+  end
 
-    # Starts the connection to listen for messages.
-    def start
-      # Empty queue name ends up creating a randomly named queue by RabbitMQ
-      # Exclusive => queue will be deleted when connection closes. Allows for automatic "cleanup".
-      @reply_queue = @channel.queue("", exclusive: true)
+  # params is an array of method argument values
+  # programmer implementing this class must know about the remote service
+  # the remote service must have documented the methods and arguments in order for this pattern to work.
+  # TODO: change to a hash to account for keyword arguments???
+  #
+  # @param remote_method [String, Symbol] the method to be called on current receiver
+  # @param params [Hash] the arguments for the method being called.
+  # @return [Object] the result of the method call.
+  def remote_call(remote_method, params)
+    correlation_id = SecureRandom.uuid
+    message = {
+      id: correlation_id,
+      jsonrpc: '2.0',
+      method: remote_method,
+      params: params.except(:controller, :action)
+    }
+    # Reply To => make sure the service knows where to send it's response.
+    # Correlation ID => identify the results that belong to the unique call made
+    @exchange.publish(message.to_json, routing_key: @server_queue.name, correlation_id: correlation_id,
+                                       reply_to: @reply_queue.name)
+    result = @results[correlation_id].pop
+    @results.delete correlation_id # remove item from hash. prevents memory leak.
+    result
+  end
 
-      # setup a hash for results with a Queue object as a value
-      @results = Hash.new{ |h, k| h[k] = Queue.new }
+  # Convience method as a resource alias for index action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def index(params)
+    remote_call('index', params)
+  end
 
-      # setup subscribe block to Service
-      # block => false is a non blocking IO option.
-      @reply_queue.subscribe(block: false) do |_delivery_info, properties, payload|
-        result = JSON.parse(payload).rename_keys('-', '_').with_indifferent_access
-        @results[properties[:correlation_id]].push(result[:result])
-      end
-    end
+  # Convience method as a resource alias for show action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def show(params)
+    remote_call('show', params)
+  end
 
-    # params is an array of method argument values
-    # programmer implementing this class must know about the remote service
-    # the remote service must have documented the methods and arguments in order for this pattern to work.
-    # TODO: change to a hash to account for keyword arguments???
-    #
-    # @param remote_method [String, Symbol] the method to be called on current receiver
-    # @param params [Hash] the arguments for the method being called.
-    # @return [Object] the result of the method call.
-    def remote_call(remote_method, params)
-      correlation_id = SecureRandom.uuid
-      message = {
-        id: correlation_id,
-        jsonrpc: '2.0',
-        method: remote_method,
-        params: params.except(:controller, :action)
-      }
-      # Reply To => make sure the service knows where to send it's response.
-      # Correlation ID => identify the results that belong to the unique call made
-      @exchange.publish(message.to_json, routing_key: @server_queue.name, correlation_id: correlation_id,
-                                         reply_to: @reply_queue.name)
-      result = @results[correlation_id].pop
-      @results.delete correlation_id # remove item from hash. prevents memory leak.
-      result
-    end
+  # Convience method as a resource alias for create action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def create(params)
+    remote_call('create', params)
+  end
 
-    # Convience method as a resource alias for index action.
-    # To customize, override the method in your class.
-    #
-    # @param params [Hash] the arguments for the method being called.
-    def index(params)
-      remote_call('index', params)
-    end
-
-    # Convience method as a resource alias for show action.
-    # To customize, override the method in your class.
-    #
-    # @param params [Hash] the arguments for the method being called.
-    def show(params)
-      remote_call('show', params)
-    end
-
-    # Convience method as a resource alias for create action.
-    # To customize, override the method in your class.
-    #
-    # @param params [Hash] the arguments for the method being called.
-    def create(params)
-      remote_call('create', params)
-    end
-
-    # Convience method as a resource alias for update action.
-    # To customize, override the method in your class.
-    #
-    # @param params [Hash] the arguments for the method being called.
-    def update(params)
-      remote_call('update', params)
-    end
+  # Convience method as a resource alias for update action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def update(params)
+    remote_call('update', params)
   end
 end

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -28,20 +28,22 @@ class CarrotRpc::RpcServer
       request_message = JSON.parse(payload).rename_keys("-", "_")
                             .with_indifferent_access
 
-      begin
-        result = send(request_message[:method], request_message[:params])
-      rescue Error => rpc_server_error
-        logger.error(rpc_server_error)
-
-        reply_error rpc_server_error.serialized_message,
-                    properties: properties,
-                    request_message: request_message
-      else
-        reply_result result,
-                     properties: properties,
-                     request_message: request_message
-      end
+      process_request(request_message, properties: properties)
     end
+  end
+
+  def process_request(request_message, properties:)
+    result = send(request_message[:method], request_message[:params])
+  rescue Error => rpc_server_error
+    logger.error(rpc_server_error)
+
+    reply_error rpc_server_error.serialized_message,
+                properties:      properties,
+                request_message: request_message
+  else
+    reply_result result,
+                 properties:      properties,
+                 request_message: request_message
   end
 
   private

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -25,7 +25,7 @@ class CarrotRpc::RpcServer
     @server_queue.subscribe(block: @block) do |_delivery_info, properties, payload|
       logger.debug "Receiving message: #{payload}"
 
-      request_message = JSON.parse(payload).rename_keys('-', '_')
+      request_message = JSON.parse(payload).rename_keys("-", "_")
                             .with_indifferent_access
 
       begin
@@ -54,7 +54,7 @@ class CarrotRpc::RpcServer
 
   # See http://www.jsonrpc.org/specification#error_object
   def reply_error(error, properties:, request_message:)
-    response_message = { error: error, id: request_message[:id], jsonrpc: '2.0' }
+    response_message = { error: error, id: request_message[:id], jsonrpc: "2.0" }
 
     logger.debug "Publish error: #{error} to #{response_message}"
 
@@ -64,7 +64,7 @@ class CarrotRpc::RpcServer
 
   # See http://www.jsonrpc.org/specification#response_object
   def reply_result(result, properties:, request_message:)
-    response_message = { id: request_message[:id], result: result, jsonrpc: '2.0' }
+    response_message = { id: request_message[:id], result: result, jsonrpc: "2.0" }
 
     logger.debug "Publishing result: #{result} to #{response_message}"
 

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -3,80 +3,77 @@ require "carrot_rpc/rpc_server/error"
 require "carrot_rpc/rpc_server/error/code"
 require "carrot_rpc/concerns/hash_extensions"
 
-# CarrotRpc gem base module.
-module CarrotRpc
-  # Base RPC Server class. Other Servers should inherit from this.
-  class RpcServer
-    using HashExtensions
+# Base RPC Server class. Other Servers should inherit from this.
+class CarrotRpc::RpcServer
+  using HashExtensions
 
-    attr_reader :channel, :server_queue, :logger
-    # method_reciver => object that receives the method. can be a class or anything responding to send
+  attr_reader :channel, :server_queue, :logger
+  # method_reciver => object that receives the method. can be a class or anything responding to send
 
-    extend ClientServer::ClassMethods
+  extend ClientServer
 
-    # Documentation advises not to share a channel connection. Create new channel for each server instance.
-    def initialize(config: nil, block: true)
-      # create a channel and exchange that both client and server know about
-      config ||= CarrotRpc.configuration
-      @channel = config.bunny.create_channel
-      @logger = config.logger
-      @block = block
-      @server_queue = @channel.queue(self.class.queue_name)
-      @exchange  = @channel.default_exchange
-    end
+  # Documentation advises not to share a channel connection. Create new channel for each server instance.
+  def initialize(config: nil, block: true)
+    # create a channel and exchange that both client and server know about
+    config ||= CarrotRpc.configuration
+    @channel = config.bunny.create_channel
+    @logger = config.logger
+    @block = block
+    @server_queue = @channel.queue(self.class.queue_name)
+    @exchange  = @channel.default_exchange
+  end
 
-    # start da server!
-    # method => object that receives the method. can be a class or anything responding to send
-    def start
-      # subscribe is like a callback
-      @server_queue.subscribe(block: @block) do |_delivery_info, properties, payload|
-        logger.debug "Receiving message: #{payload}"
+  # start da server!
+  # method => object that receives the method. can be a class or anything responding to send
+  def start
+    # subscribe is like a callback
+    @server_queue.subscribe(block: @block) do |_delivery_info, properties, payload|
+      logger.debug "Receiving message: #{payload}"
 
-        request_message = JSON.parse(payload).rename_keys('-', '_')
+      request_message = JSON.parse(payload).rename_keys('-', '_')
                           .with_indifferent_access
 
-        begin
-          result = self.send(request_message[:method], request_message[:params])
-        rescue Error => rpc_server_error
-          logger.error(rpc_server_error)
+      begin
+        result = self.send(request_message[:method], request_message[:params])
+      rescue Error => rpc_server_error
+        logger.error(rpc_server_error)
 
-          reply_error rpc_server_error.serialized_message,
-                      properties: properties,
-                      request_message: request_message
-        else
-          reply_result result,
-                       properties: properties,
-                       request_message: request_message
-        end
+        reply_error rpc_server_error.serialized_message,
+                    properties: properties,
+                    request_message: request_message
+      else
+        reply_result result,
+                     properties: properties,
+                     request_message: request_message
       end
     end
+  end
 
-    private
+  private
 
-    def reply(properties:, response_message:)
-      @exchange.publish response_message.to_json,
-                        correlation_id: properties.correlation_id,
-                        routing_key: properties.reply_to
-    end
+  def reply(properties:, response_message:)
+    @exchange.publish response_message.to_json,
+                      correlation_id: properties.correlation_id,
+                      routing_key: properties.reply_to
+  end
 
-    # See http://www.jsonrpc.org/specification#error_object
-    def reply_error(error, properties:, request_message:)
-      response_message = { error: error, id: request_message[:id], jsonrpc: '2.0' }
+  # See http://www.jsonrpc.org/specification#error_object
+  def reply_error(error, properties:, request_message:)
+    response_message = { error: error, id: request_message[:id], jsonrpc: '2.0' }
 
-      logger.debug "Publish error: #{error} to #{response_message}"
+    logger.debug "Publish error: #{error} to #{response_message}"
 
-      reply properties: properties,
-            response_message: response_message
-    end
+    reply properties: properties,
+          response_message: response_message
+  end
 
-    # See http://www.jsonrpc.org/specification#response_object
-    def reply_result(result, properties:, request_message:)
-      response_message = { id: request_message[:id], result: result, jsonrpc: '2.0' }
+  # See http://www.jsonrpc.org/specification#response_object
+  def reply_result(result, properties:, request_message:)
+    response_message = { id: request_message[:id], result: result, jsonrpc: '2.0' }
 
-      logger.debug "Publishing result: #{result} to #{response_message}"
+    logger.debug "Publishing result: #{result} to #{response_message}"
 
-      reply properties: properties,
-            response_message: response_message
-    end
+    reply properties: properties,
+          response_message: response_message
   end
 end

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -1,16 +1,11 @@
-require "carrot_rpc/concerns/client_server"
-require "carrot_rpc/rpc_server/error"
-require "carrot_rpc/rpc_server/error/code"
-require "carrot_rpc/concerns/hash_extensions"
-
 # Base RPC Server class. Other Servers should inherit from this.
 class CarrotRpc::RpcServer
-  using HashExtensions
+  using CarrotRpc::HashExtensions
 
   attr_reader :channel, :server_queue, :logger
   # method_reciver => object that receives the method. can be a class or anything responding to send
 
-  extend ClientServer
+  extend CarrotRpc::ClientServer
 
   # Documentation advises not to share a channel connection. Create new channel for each server instance.
   def initialize(config: nil, block: true)

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -45,8 +45,8 @@ module CarrotRpc
                       request_message: request_message
         else
           reply_result result,
-                      properties: properties,
-                      request_message: request_message
+                       properties: properties,
+                       request_message: request_message
         end
       end
     end

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -29,7 +29,7 @@ module CarrotRpc
     # method => object that receives the method. can be a class or anything responding to send
     def start
       # subscribe is like a callback
-      @server_queue.subscribe(block: @block) do |delivery_info, properties, payload|
+      @server_queue.subscribe(block: @block) do |_delivery_info, properties, payload|
         logger.debug "Receiving message: #{payload}"
 
         request_message = JSON.parse(payload).rename_keys('-', '_')

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -15,7 +15,7 @@ class CarrotRpc::RpcServer
     @logger = config.logger
     @block = block
     @server_queue = @channel.queue(self.class.queue_name)
-    @exchange  = @channel.default_exchange
+    @exchange = @channel.default_exchange
   end
 
   # start da server!

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -26,7 +26,7 @@ class CarrotRpc::RpcServer
       logger.debug "Receiving message: #{payload}"
 
       request_message = JSON.parse(payload).rename_keys('-', '_')
-                          .with_indifferent_access
+                            .with_indifferent_access
 
       begin
         result = self.send(request_message[:method], request_message[:params])

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -21,7 +21,7 @@ module CarrotRpc
       @channel = config.bunny.create_channel
       @logger = config.logger
       @block = block
-      @server_queue = @channel.queue(self.class.get_queue_name)
+      @server_queue = @channel.queue(self.class.queue_name)
       @exchange  = @channel.default_exchange
     end
 

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -29,7 +29,7 @@ class CarrotRpc::RpcServer
                             .with_indifferent_access
 
       begin
-        result = self.send(request_message[:method], request_message[:params])
+        result = send(request_message[:method], request_message[:params])
       rescue Error => rpc_server_error
         logger.error(rpc_server_error)
 

--- a/lib/carrot_rpc/rpc_server/error.rb
+++ b/lib/carrot_rpc/rpc_server/error.rb
@@ -1,43 +1,41 @@
 # Error raised by an {RpcServer} method to signal that a
 # {http://www.jsonrpc.org/specification#error_object JSON RPC 2.0 Response Error object} should be the reply.
-module CarrotRpc
-  class Error < StandardError
-    # @return [Integer]A Number that indicates the error type that occurred. Some codes are
-    #   {http://www.jsonrpc.org/specification#error_object predefined}.
-    attr_reader :code
+class CarrotRpc::Error < StandardError
+  # @return [Integer]A Number that indicates the error type that occurred. Some codes are
+  #   {http://www.jsonrpc.org/specification#error_object predefined}.
+  attr_reader :code
 
-    # @return [Object, nil] A Primitive or Structured value that contains additional information about the error.
-    #   This may be omitted. The value of this member is defined by the Server (e.g. detailed error information,
-    #   nested errors etc.).
-    attr_reader :data
+  # @return [Object, nil] A Primitive or Structured value that contains additional information about the error.
+  #   This may be omitted. The value of this member is defined by the Server (e.g. detailed error information,
+  #   nested errors etc.).
+  attr_reader :data
 
-    # @param code [Integer] A Number that indicates the error type that occurred.  Favor using the
-    #   {http://www.jsonrpc.org/specification#error_object predefined codes}.
-    # @param message [String] A String providing a short description of the error. The message SHOULD be limited to a
-    #   concise single sentence.
-    # @param data [Object, nil] A Primitive or Structured value that contains additional information about the error.
-    #   This may be omitted. The value of this member is defined by the Server (e.g. detailed error information,
-    #   nested errors etc.).
-    def initialize(code:, message:, data: nil)
-      @code = code
-      @data = data
-      super(message)
+  # @param code [Integer] A Number that indicates the error type that occurred.  Favor using the
+  #   {http://www.jsonrpc.org/specification#error_object predefined codes}.
+  # @param message [String] A String providing a short description of the error. The message SHOULD be limited to a
+  #   concise single sentence.
+  # @param data [Object, nil] A Primitive or Structured value that contains additional information about the error.
+  #   This may be omitted. The value of this member is defined by the Server (e.g. detailed error information,
+  #   nested errors etc.).
+  def initialize(code:, message:, data: nil)
+    @code = code
+    @data = data
+    super(message)
+  end
+
+  # A properly formatted {http://www.jsonrpc.org/specification#error_object JSON RPC Error object}.
+  #
+  # @return [Hash{code: String, message: String}, Hash{code: String, data: Object, message: String}]
+  def serialized_message
+    serialized = {
+      code: code,
+      message: message
+    }
+
+    if data
+      serialized[:data] = data
     end
 
-    # A properly formatted {http://www.jsonrpc.org/specification#error_object JSON RPC Error object}.
-    #
-    # @return [Hash{code: String, message: String}, Hash{code: String, data: Object, message: String}]
-    def serialized_message
-      serialized = {
-          code: code,
-          message: message
-      }
-
-      if data
-        serialized[:data] = data
-      end
-
-      serialized
-    end
+    serialized
   end
 end

--- a/lib/carrot_rpc/rpc_server/error/code.rb
+++ b/lib/carrot_rpc/rpc_server/error/code.rb
@@ -1,17 +1,17 @@
 # An enum of predefined {RpcServer::Server#code}
 module CarrotRpc::Error::Code
   # Internal JSON-RPC error.
-  INTERNAL_ERROR   = -32603
+  INTERNAL_ERROR   = -32_603
 
   # Invalid method parameter(s).
-  INVALID_PARAMS   = -32602
+  INVALID_PARAMS   = -32_602
 
   # The JSON sent is not a valid Request object.
-  INVALID_REQUEST  = -32600
+  INVALID_REQUEST  = -32_600
 
   # The method does not exist / is not available.
-  METHOD_NOT_FOUND = -32601
+  METHOD_NOT_FOUND = -32_601
 
   # Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
-  PARSE_ERROR      = -32700
+  PARSE_ERROR      = -32_700
 end

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -77,7 +77,7 @@ module CarrotRpc
     # Path should already be expanded.
     def load_rails_app(path)
       rails_path = File.join(path, 'config/environment.rb')
-      if File.exists?(rails_path)
+      if File.exist?(rails_path)
         logger.info "Rails app found at: #{rails_path}"
         ENV['RACK_ENV'] ||= ENV['RAILS_ENV'] || 'development'
         require rails_path
@@ -108,7 +108,7 @@ module CarrotRpc
       if pidfile?
         begin
           File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY){|f| f.write("#{Process.pid}") }
-          at_exit { File.delete(pidfile) if File.exists?(pidfile) }
+          at_exit { File.delete(pidfile) if File.exist?(pidfile) }
         rescue Errno::EEXIST
           check_pid
           retry
@@ -131,7 +131,7 @@ module CarrotRpc
 
     # Set the process id file. Required for backgrounding.
     def pid_status(pidfile)
-      return :exited unless File.exists?(pidfile)
+      return :exited unless File.exist?(pidfile)
       pid = ::File.read(pidfile).to_i
       return :dead if pid == 0
       Process.kill(0, pid)      # check process status

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -52,7 +52,7 @@ class CarrotRpc::ServerRunner
 
   # Shutdown all servers defined.
   def stop_servers
-    logger.info "Quit signal received!"
+    logger.info "#{@siginal_name} signal received!"
     @servers.each do |s|
       logger.info "Shutting Down Server Queue: #{s.queue.name}"
       s.channel.close
@@ -130,15 +130,17 @@ class CarrotRpc::ServerRunner
   end
 
   # Set a value to signal shutdown.
-  def shutdown
+  def shutdown(name)
+    @signal_name = name
     @quit = true
   end
 
   # Handle signal events.
   def trap_signals
     CarrotRpc::ServerRunner::Signals.trap do |name|
-      logger.info "#{name} Little bunny foo foo is a Goon....closing connection to RabbitMQ"
-      shutdown
+      # @note can't log from a trap context: since Ruby 2.0 traps don't allow mutexes as it could lead to a dead lock,
+      #   so `logger.info` here would return "log writing failed. can't be called from trap context"
+      shutdown(name)
     end
   end
 

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -118,10 +118,10 @@ class CarrotRpc::ServerRunner
     if pidfile?
       case pid_status(pidfile)
       when :running, :not_owned
-          logger.warn "A server is already running. Check #{pidfile}"
-          exit(1)
+        logger.warn "A server is already running. Check #{pidfile}"
+        exit(1)
       when :dead
-          File.delete(pidfile)
+        File.delete(pidfile)
       end
     end
   end

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -19,7 +19,7 @@ module CarrotRpc
     # Start the servers and the run loop.
     def run!
       check_pid
-      daemonize and suppress_output if daemonize?
+      daemonize && suppress_output if daemonize?
       write_pid
 
       # Initialize the servers. Set logger.

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -56,7 +56,7 @@ class CarrotRpc::ServerRunner
     # Load each server defined in the project dir
     files.each do |file|
       require file
-      server_klass = eval file.to_s.split("/").last.gsub(".rb", "").split("_").collect! { |w| w.capitalize }.join
+      server_klass = eval file.to_s.split("/").last.gsub(".rb", "").split("_").collect!(&:capitalize).join
       logger.info "Starting #{server_klass}..."
 
       server = server_klass.new(block: false)

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -54,7 +54,7 @@ class CarrotRpc::ServerRunner
   def stop_servers
     logger.info "#{@siginal_name} signal received!"
     @servers.each do |s|
-      logger.info "Shutting Down Server Queue: #{s.queue.name}"
+      logger.info "Shutting Down Server Queue: #{s.server_queue.name}"
       s.channel.close
     end
     # Close the connection once all the other servers are shutdown

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -46,7 +46,7 @@ class CarrotRpc::ServerRunner
   # @return [Array] of RpcServers loaded and initialized
   def run_servers(dirs: ["app", "servers"])
     regex = %r{\A/.*/#{dirs.join("/")}\z}
-    server_path = $:.find do |p|
+    server_path = $LOAD_PATH.find do |p|
       p.match(regex)
     end + "/*.rb"
 

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/string/inflections"
+
 # Automatically detects, loads, and runs all {CarrotRpc::RpcServer} subclasses under `app/servers` in the project root.
 class CarrotRpc::ServerRunner
   extend ActiveSupport::Autoload
@@ -76,7 +78,9 @@ class CarrotRpc::ServerRunner
 
   def run_server_file(file)
     require file
-    server_klass = eval file.to_s.split("/").last.gsub(".rb", "").split("_").collect!(&:capitalize).join
+    server_klass_name = file.to_s.split("/").last.gsub(".rb", "").camelize
+    server_klass = server_klass_name.constantize
+
     logger.info "Starting #{server_klass}..."
 
     server = server_klass.new(block: false)

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -1,5 +1,3 @@
-require "carrot_rpc"
-
 class CarrotRpc::ServerRunner
   attr_reader :quit, :servers
 

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -194,10 +194,10 @@ class CarrotRpc::ServerRunner
     logger = log_from_file
 
     if defined?(::Rails)
-      logger = Rails.logger if logger.nil?
+      logger ||= Rails.logger
       CarrotRpc::TaggedLog.new(logger: logger, tags: ["Carrot RPC"])
     else
-      logger = Logger.new(STDOUT) if logger.nil?
+      logger ||= Logger.new(STDOUT)
     end
 
     logger.level = CarrotRpc.configuration.loglevel

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -44,7 +44,7 @@ class CarrotRpc::ServerRunner
   # Find and require all servers in the app/servers dir.
   # @param dirs [Array] directories relative to root of host application where RpcServers can be loaded
   # @return [Array] of RpcServers loaded and initialized
-  def run_servers(dirs: ["app", "servers"])
+  def run_servers(dirs: %w(app servers))
     regex = %r{\A/.*/#{dirs.join("/")}\z}
     server_path = $LOAD_PATH.find do |p|
       p.match(regex)

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -23,7 +23,7 @@ class CarrotRpc::ServerRunner
     run_servers
 
     # Sleep for a split second.
-    while !quit
+    until quit
       sleep @runloop_sleep
     end
     # When runtime gets here, quit signal is received.

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -45,7 +45,7 @@ class CarrotRpc::ServerRunner
   # @param dirs [Array] directories relative to root of host application where RpcServers can be loaded
   # @return [Array] of RpcServers loaded and initialized
   def run_servers(dirs: ["app", "servers"])
-    regex = /\A\/.*\/#{dirs.join("/")}\z/
+    regex = %r{\A/.*/#{dirs.join("/")}\z}
     server_path = $:.find do |p|
       p.match(regex)
     end + "/*.rb"

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -56,7 +56,7 @@ class CarrotRpc::ServerRunner
     # Load each server defined in the project dir
     files.each do |file|
       require file
-      server_klass = eval file.to_s.split('/').last.gsub('.rb', '').split("_").collect!{ |w| w.capitalize}.join
+      server_klass = eval file.to_s.split('/').last.gsub('.rb', '').split("_").collect! { |w| w.capitalize }.join
       logger.info "Starting #{server_klass}..."
 
       server = server_klass.new(block: false)
@@ -104,7 +104,7 @@ class CarrotRpc::ServerRunner
   def write_pid
     if pidfile?
       begin
-        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY){|f| f.write("#{Process.pid}") }
+        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) { |f| f.write("#{Process.pid}") }
         at_exit { File.delete(pidfile) if File.exist?(pidfile) }
       rescue Errno::EEXIST
         check_pid

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -56,7 +56,7 @@ class CarrotRpc::ServerRunner
     # Load each server defined in the project dir
     files.each do |file|
       require file
-      server_klass = eval file.to_s.split('/').last.gsub('.rb', '').split("_").collect! { |w| w.capitalize }.join
+      server_klass = eval file.to_s.split("/").last.gsub(".rb", "").split("_").collect! { |w| w.capitalize }.join
       logger.info "Starting #{server_klass}..."
 
       server = server_klass.new(block: false)
@@ -73,10 +73,10 @@ class CarrotRpc::ServerRunner
 
   # Path should already be expanded.
   def load_rails_app(path)
-    rails_path = File.join(path, 'config/environment.rb')
+    rails_path = File.join(path, "config/environment.rb")
     if File.exist?(rails_path)
       logger.info "Rails app found at: #{rails_path}"
-      ENV['RACK_ENV'] ||= ENV['RAILS_ENV'] || 'development'
+      ENV["RACK_ENV"] ||= ENV["RAILS_ENV"] || "development"
       require rails_path
       ::Rails.application.eager_load!
       true
@@ -149,7 +149,7 @@ class CarrotRpc::ServerRunner
 
   # Part of daemonizing process. Prevents application from outputting info to terminal.
   def suppress_output
-    $stderr.reopen('/dev/null', 'a')
+    $stderr.reopen("/dev/null", "a")
     $stdout.reopen($stderr)
   end
 

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -82,9 +82,9 @@ class CarrotRpc::ServerRunner
 
   def server_glob(dirs)
     regex = %r{\A/.*/#{dirs.join("/")}\z}
-    $LOAD_PATH.find do |p|
+    $LOAD_PATH.find { |p|
       p.match(regex)
-    end + "/*.rb"
+    } + "/*.rb"
   end
 
   # Convenience method to wrap the logger object.
@@ -128,7 +128,10 @@ class CarrotRpc::ServerRunner
   def write_pid
     if pidfile?
       begin
-        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) { |f| f.write(Process.pid.to_s) }
+        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) do |f|
+          f.write(Process.pid.to_s)
+        end
+
         at_exit { File.delete(pidfile) if File.exist?(pidfile) }
       rescue Errno::EEXIST
         check_pid

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -49,9 +49,9 @@ module CarrotRpc
     # @return [Array] of RpcServers loaded and initialized
     def run_servers(dirs: ["app", "servers"])
       regex = /\A\/.*\/#{dirs.join("/")}\z/
-      server_path = $:.select do |p|
+      server_path = $:.find do |p|
         p.match(regex)
-      end.first + "/*.rb"
+      end + "/*.rb"
 
       files = Dir[server_path]
       fail "No servers found!" if files.empty?

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -1,12 +1,18 @@
 # Automatically detects, loads, and runs all {CarrotRpc::RpcServer} subclasses under `app/servers` in the project root.
 class CarrotRpc::ServerRunner
-  # CONSTANTS
+  extend ActiveSupport::Autoload
 
-  TRAPPED_SIGNALS = %w(HUP INT QUIT TERM).freeze
+  autoload :AutoloadRails
+  autoload :Logger
+  autoload :Pid
+  autoload :Signals
 
   # Attributes
 
   attr_reader :quit, :servers
+
+  # @return [CarrotRpc::ServerRunner::Pid]
+  attr_reader :pid
 
   # Methods
 
@@ -15,18 +21,21 @@ class CarrotRpc::ServerRunner
     @runloop_sleep = runloop_sleep
     @daemonize = daemonize
     @servers = []
-    load_rails_app(rails_path) if CarrotRpc.configuration.autoload_rails
+
+    CarrotRpc::ServerRunner::AutoloadRails.conditionally_load_root(rails_path, logger: logger)
     trap_signals
 
-    # daemonization will change CWD so expand relative paths now
-    @pidfile = File.expand_path(pidfile) if pidfile
+    @pid = CarrotRpc::ServerRunner::Pid.new(
+      path:   pidfile,
+      logger: logger
+    )
   end
 
   # Start the servers and the run loop.
   def run!
-    check_pid
+    pid.check
     daemonize && suppress_output if daemonize?
-    write_pid
+    pid.ensure_written
 
     # Initialize the servers. Set logger.
     run_servers
@@ -92,20 +101,6 @@ class CarrotRpc::ServerRunner
     @logger ||= set_logger
   end
 
-  # Path should already be expanded.
-  def load_rails_app(path)
-    rails_path = File.join(path, "config/environment.rb")
-    if File.exist?(rails_path)
-      logger.info "Rails app found at: #{rails_path}"
-      ENV["RACK_ENV"] ||= ENV["RAILS_ENV"] || "development"
-      require rails_path
-      ::Rails.application.eager_load!
-      true
-    else
-      require rails_path
-    end
-  end
-
   # attr_reader doesn't allow adding a `?` to the method name, so I think this is a false positive
   # rubocop:disable Style/TrivialAccessors
 
@@ -115,56 +110,6 @@ class CarrotRpc::ServerRunner
   end
 
   # rubocop:enable Style/TrivialAccessors
-
-  # Attribute accessor for pid file options
-  attr_reader :pidfile
-
-  # pid file present?
-  def pidfile?
-    !pidfile.nil?
-  end
-
-  # Write to process id file is one does not exist.
-  def write_pid
-    if pidfile?
-      begin
-        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) do |f|
-          f.write(Process.pid.to_s)
-        end
-
-        at_exit { File.delete(pidfile) if File.exist?(pidfile) }
-      rescue Errno::EEXIST
-        check_pid
-        retry
-      end
-    end
-  end
-
-  # Determine if a process id file is already present.
-  def check_pid
-    if pidfile?
-      case pid_status(pidfile)
-      when :running, :not_owned
-        logger.warn "A server is already running. Check #{pidfile}"
-        exit(1)
-      when :dead
-        File.delete(pidfile)
-      end
-    end
-  end
-
-  # Set the process id file. Required for backgrounding.
-  def pid_status(pidfile)
-    return :exited unless File.exist?(pidfile)
-    pid = ::File.read(pidfile).to_i
-    return :dead if pid == 0
-    Process.kill(0, pid) # check process status
-    :running
-  rescue Errno::ESRCH
-    :dead
-  rescue Errno::EPERM
-    :not_owned
-  end
 
   # Background the ruby process.
   def daemonize
@@ -187,39 +132,19 @@ class CarrotRpc::ServerRunner
 
   # Handle signal events.
   def trap_signals
-    TRAPPED_SIGNALS.each do |trapped_signal|
-      trap(trapped_signal) do
-        trap_shutdown(trapped_signal)
-      end
+    CarrotRpc::ServerRunner::Signals.trap do |name|
+      logger.info "#{name} Little bunny foo foo is a Goon....closing connection to RabbitMQ"
+      shutdown
     end
-  end
-
-  def trap_shutdown(signal_name)
-    logger.info "#{signal_name} Little bunny foo foo is a Goon....closing connection to RabbitMQ"
-    shutdown
   end
 
   private
 
   # Determine how to create logger. Config can specify log file.
   def set_logger
-    # always try to create a logger from file
-    logger = log_from_file
-
-    if defined?(::Rails)
-      logger ||= Rails.logger
-      CarrotRpc::TaggedLog.new(logger: logger, tags: ["Carrot RPC"])
-    else
-      logger ||= Logger.new(STDOUT)
-    end
-
-    logger.level = CarrotRpc.configuration.loglevel
+    logger = CarrotRpc::ServerRunner::Logger.configured
     CarrotRpc.configuration.logger = logger
-    logger
-  end
 
-  def log_from_file
-    return nil unless CarrotRpc.configuration.logfile
-    Logger.new(CarrotRpc.configuration.logfile)
+    logger
   end
 end

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -1,3 +1,4 @@
+# Automatically detects, loads, and runs all {CarrotRpc::RpcServer} subclasses under `app/servers` in the project root.
 class CarrotRpc::ServerRunner
   attr_reader :quit, :servers
 

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -131,7 +131,7 @@ class CarrotRpc::ServerRunner
     return :exited unless File.exist?(pidfile)
     pid = ::File.read(pidfile).to_i
     return :dead if pid == 0
-    Process.kill(0, pid)      # check process status
+    Process.kill(0, pid) # check process status
     :running
   rescue Errno::ESRCH
     :dead

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -107,7 +107,7 @@ class CarrotRpc::ServerRunner
   def write_pid
     if pidfile?
       begin
-        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) { |f| f.write("#{Process.pid}") }
+        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) { |f| f.write(Process.pid.to_s) }
         at_exit { File.delete(pidfile) if File.exist?(pidfile) }
       rescue Errno::EEXIST
         check_pid

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -85,15 +85,18 @@ class CarrotRpc::ServerRunner
     end
   end
 
+  # attr_reader doesn't allow adding a `?` to the method name, so I think this is a false positive
+  # rubocop:disable Style/TrivialAccessors
+
   # Attribute to determine when to daemonize the process.
   def daemonize?
     @daemonize
   end
 
+  # rubocop:enable Style/TrivialAccessors
+
   # Attribute accessor for pid file options
-  def pidfile
-    @pidfile
-  end
+  attr_reader :pidfile
 
   # pid file present?
   def pidfile?

--- a/lib/carrot_rpc/server_runner.rb
+++ b/lib/carrot_rpc/server_runner.rb
@@ -1,216 +1,214 @@
 require "carrot_rpc"
 
-module CarrotRpc
-  class ServerRunner
-    attr_reader :quit, :servers
+class CarrotRpc::ServerRunner
+  attr_reader :quit, :servers
 
-    # Instantiate the ServerRunner.
-    def initialize(rails_path: ".", pidfile: nil, runloop_sleep: 0, daemonize: false)
-      @runloop_sleep = runloop_sleep
-      @daemonize = daemonize
-      @servers = []
-      load_rails_app(rails_path) if CarrotRpc.configuration.autoload_rails
-      trap_signals
+  # Instantiate the ServerRunner.
+  def initialize(rails_path: ".", pidfile: nil, runloop_sleep: 0, daemonize: false)
+    @runloop_sleep = runloop_sleep
+    @daemonize = daemonize
+    @servers = []
+    load_rails_app(rails_path) if CarrotRpc.configuration.autoload_rails
+    trap_signals
 
-      # daemonization will change CWD so expand relative paths now
-      @pidfile = File.expand_path(pidfile) if pidfile
+    # daemonization will change CWD so expand relative paths now
+    @pidfile = File.expand_path(pidfile) if pidfile
+  end
+
+  # Start the servers and the run loop.
+  def run!
+    check_pid
+    daemonize && suppress_output if daemonize?
+    write_pid
+
+    # Initialize the servers. Set logger.
+    run_servers
+
+    # Sleep for a split second.
+    while !quit
+      sleep @runloop_sleep
     end
+    # When runtime gets here, quit signal is received.
+    stop_servers
+  end
 
-    # Start the servers and the run loop.
-    def run!
-      check_pid
-      daemonize && suppress_output if daemonize?
-      write_pid
-
-      # Initialize the servers. Set logger.
-      run_servers
-
-      # Sleep for a split second.
-      while !quit
-        sleep @runloop_sleep
-      end
-      # When runtime gets here, quit signal is received.
-      stop_servers
+  # Shutdown all servers defined.
+  def stop_servers
+    logger.info "Quit signal received!"
+    @servers.each do |s|
+      logger.info "Shutting Down Server Queue: #{s.queue.name}"
+      s.channel.close
     end
+    # Close the connection once all the other servers are shutdown
+    CarrotRpc.configuration.bunny.close
+  end
 
-    # Shutdown all servers defined.
-    def stop_servers
-      logger.info "Quit signal received!"
-      @servers.each do |s|
-        logger.info "Shutting Down Server Queue: #{s.queue.name}"
-        s.channel.close
-      end
-      # Close the connection once all the other servers are shutdown
-      CarrotRpc.configuration.bunny.close
+  # Find and require all servers in the app/servers dir.
+  # @param dirs [Array] directories relative to root of host application where RpcServers can be loaded
+  # @return [Array] of RpcServers loaded and initialized
+  def run_servers(dirs: ["app", "servers"])
+    regex = /\A\/.*\/#{dirs.join("/")}\z/
+    server_path = $:.find do |p|
+      p.match(regex)
+    end + "/*.rb"
+
+    files = Dir[server_path]
+    fail "No servers found!" if files.empty?
+
+    # Load each server defined in the project dir
+    files.each do |file|
+      require file
+      server_klass = eval file.to_s.split('/').last.gsub('.rb', '').split("_").collect!{ |w| w.capitalize}.join
+      logger.info "Starting #{server_klass}..."
+
+      server = server_klass.new(block: false)
+      server.start
+      @servers << server
     end
+    @servers
+  end
 
-    # Find and require all servers in the app/servers dir.
-    # @param dirs [Array] directories relative to root of host application where RpcServers can be loaded
-    # @return [Array] of RpcServers loaded and initialized
-    def run_servers(dirs: ["app", "servers"])
-      regex = /\A\/.*\/#{dirs.join("/")}\z/
-      server_path = $:.find do |p|
-        p.match(regex)
-      end + "/*.rb"
+  # Convenience method to wrap the logger object.
+  def logger
+    @logger ||= set_logger
+  end
 
-      files = Dir[server_path]
-      fail "No servers found!" if files.empty?
-
-      # Load each server defined in the project dir
-      files.each do |file|
-        require file
-        server_klass = eval file.to_s.split('/').last.gsub('.rb', '').split("_").collect!{ |w| w.capitalize}.join
-        logger.info "Starting #{server_klass}..."
-
-        server = server_klass.new(block: false)
-        server.start
-        @servers << server
-      end
-      @servers
+  # Path should already be expanded.
+  def load_rails_app(path)
+    rails_path = File.join(path, 'config/environment.rb')
+    if File.exist?(rails_path)
+      logger.info "Rails app found at: #{rails_path}"
+      ENV['RACK_ENV'] ||= ENV['RAILS_ENV'] || 'development'
+      require rails_path
+      ::Rails.application.eager_load!
+      true
+    else
+      require rails_path
     end
+  end
 
-    # Convenience method to wrap the logger object.
-    def logger
-      @logger ||= set_logger
-    end
+  # Attribute to determine when to daemonize the process.
+  def daemonize?
+    @daemonize
+  end
 
-    # Path should already be expanded.
-    def load_rails_app(path)
-      rails_path = File.join(path, 'config/environment.rb')
-      if File.exist?(rails_path)
-        logger.info "Rails app found at: #{rails_path}"
-        ENV['RACK_ENV'] ||= ENV['RAILS_ENV'] || 'development'
-        require rails_path
-        ::Rails.application.eager_load!
-        true
-      else
-        require rails_path
-      end
-    end
+  # Attribute accessor for pid file options
+  def pidfile
+    @pidfile
+  end
 
-    # Attribute to determine when to daemonize the process.
-    def daemonize?
-      @daemonize
-    end
+  # pid file present?
+  def pidfile?
+    !pidfile.nil?
+  end
 
-    # Attribute accessor for pid file options
-    def pidfile
-      @pidfile
-    end
-
-    # pid file present?
-    def pidfile?
-      !pidfile.nil?
-    end
-
-    # Write to process id file is one does not exist.
-    def write_pid
-      if pidfile?
-        begin
-          File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY){|f| f.write("#{Process.pid}") }
-          at_exit { File.delete(pidfile) if File.exist?(pidfile) }
-        rescue Errno::EEXIST
-          check_pid
-          retry
-        end
+  # Write to process id file is one does not exist.
+  def write_pid
+    if pidfile?
+      begin
+        File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY){|f| f.write("#{Process.pid}") }
+        at_exit { File.delete(pidfile) if File.exist?(pidfile) }
+      rescue Errno::EEXIST
+        check_pid
+        retry
       end
     end
+  end
 
-    # Determine if a process id file is already present.
-    def check_pid
-      if pidfile?
-        case pid_status(pidfile)
-        when :running, :not_owned
+  # Determine if a process id file is already present.
+  def check_pid
+    if pidfile?
+      case pid_status(pidfile)
+      when :running, :not_owned
           logger.warn "A server is already running. Check #{pidfile}"
           exit(1)
-        when :dead
+      when :dead
           File.delete(pidfile)
-        end
       end
     end
+  end
 
-    # Set the process id file. Required for backgrounding.
-    def pid_status(pidfile)
-      return :exited unless File.exist?(pidfile)
-      pid = ::File.read(pidfile).to_i
-      return :dead if pid == 0
-      Process.kill(0, pid)      # check process status
-      :running
-    rescue Errno::ESRCH
-      :dead
-    rescue Errno::EPERM
-      :not_owned
+  # Set the process id file. Required for backgrounding.
+  def pid_status(pidfile)
+    return :exited unless File.exist?(pidfile)
+    pid = ::File.read(pidfile).to_i
+    return :dead if pid == 0
+    Process.kill(0, pid)      # check process status
+    :running
+  rescue Errno::ESRCH
+    :dead
+  rescue Errno::EPERM
+    :not_owned
+  end
+
+  # Background the ruby process.
+  def daemonize
+    exit if fork
+    Process.setsid
+    exit if fork
+    Dir.chdir "/"
+  end
+
+  # Part of daemonizing process. Prevents application from outputting info to terminal.
+  def suppress_output
+    $stderr.reopen('/dev/null', 'a')
+    $stdout.reopen($stderr)
+  end
+
+  # Set a value to signal shutdown.
+  def shutdown
+    @quit = true
+  end
+
+  # Handle signal events.
+  def trap_signals
+    # graceful shutdown of run! loop
+    trap(:QUIT) do
+      logger.info "QUIT Little bunny foo foo is a Goon....closing connection to RabbitMQ"
+      shutdown
+    end
+    # Handle Ctrl-C
+    trap("INT") do
+      logger.info "INT Little bunny foo foo is a Goon....closing connection to RabbitMQ"
+      shutdown
     end
 
-    # Background the ruby process.
-    def daemonize
-      exit if fork
-      Process.setsid
-      exit if fork
-      Dir.chdir "/"
+    # Handle Hangup
+    trap("HUP") do
+      logger.info "HUP Little bunny foo foo is a Goon....closing connection to RabbitMQ"
+      shutdown
     end
 
-    # Part of daemonizing process. Prevents application from outputting info to terminal.
-    def suppress_output
-      $stderr.reopen('/dev/null', 'a')
-      $stdout.reopen($stderr)
+    # Handles `Kill` signals
+    trap("TERM") do
+      # Documentation says closing connection will first close the channels belonging to the connection
+      # Alternatively a channel can be closed independently ```channel.close```
+      logger.info "TERM Little bunny foo foo is a Goon....closing connection to RabbitMQ"
+      shutdown
+    end
+  end
+
+  private
+
+  # Determine how to create logger. Config can specify log file.
+  def set_logger
+    # always try to create a logger from file
+    logger = log_from_file
+
+    if defined?(::Rails)
+      logger = Rails.logger if logger.nil?
+      CarrotRpc::TaggedLog.new(logger: logger, tags: ["Carrot RPC"])
+    else
+      logger = Logger.new(STDOUT) if logger.nil?
     end
 
-    # Set a value to signal shutdown.
-    def shutdown
-      @quit = true
-    end
+    logger.level = CarrotRpc.configuration.loglevel
+    CarrotRpc.configuration.logger = logger
+    logger
+  end
 
-    # Handle signal events.
-    def trap_signals
-      # graceful shutdown of run! loop
-      trap(:QUIT) do
-        logger.info "QUIT Little bunny foo foo is a Goon....closing connection to RabbitMQ"
-        shutdown
-      end
-      # Handle Ctrl-C
-      trap("INT") do
-        logger.info "INT Little bunny foo foo is a Goon....closing connection to RabbitMQ"
-        shutdown
-      end
-
-      # Handle Hangup
-      trap("HUP") do
-        logger.info "HUP Little bunny foo foo is a Goon....closing connection to RabbitMQ"
-        shutdown
-      end
-
-      # Handles `Kill` signals
-      trap("TERM") do
-        # Documentation says closing connection will first close the channels belonging to the connection
-        # Alternatively a channel can be closed independently ```channel.close```
-        logger.info "TERM Little bunny foo foo is a Goon....closing connection to RabbitMQ"
-        shutdown
-      end
-    end
-
-    private
-
-    # Determine how to create logger. Config can specify log file.
-    def set_logger
-      # always try to create a logger from file
-      logger = log_from_file
-
-      if defined?(::Rails)
-        logger = Rails.logger if logger.nil?
-        CarrotRpc::TaggedLog.new(logger: logger, tags: ["Carrot RPC"])
-      else
-        logger = Logger.new(STDOUT) if logger.nil?
-      end
-
-      logger.level = CarrotRpc.configuration.loglevel
-      CarrotRpc.configuration.logger = logger
-      logger
-    end
-
-    def log_from_file
-      return nil unless CarrotRpc.configuration.logfile
-      Logger.new(CarrotRpc.configuration.logfile)
-    end
+  def log_from_file
+    return nil unless CarrotRpc.configuration.logfile
+    Logger.new(CarrotRpc.configuration.logfile)
   end
 end

--- a/lib/carrot_rpc/server_runner/autoload_rails.rb
+++ b/lib/carrot_rpc/server_runner/autoload_rails.rb
@@ -1,0 +1,41 @@
+# Loads the Rails application so that the servers can use the Rails gems and environment.
+module CarrotRpc::ServerRunner::AutoloadRails
+  # Path to the `config/environment.rb`, which is the file that must actually be `require`d to load Rails.
+  #
+  # @param root [String] path to the root of the Rails app
+  # @return [String]
+  def self.environment_path(root)
+    File.join(root, "config/environment.rb")
+  end
+
+  # Attempts to load Rails app at `root`.
+  #
+  # @param root [String] path to the root of the Rails app
+  # @param logger [Logger] logger to print success to.
+  # @return [true]
+  # @raise [LoadError] if rails cannot be loaded
+  def self.load_root(root, logger:)
+    rails_path = environment_path(root)
+
+    if File.exist?(rails_path)
+      logger.info "Rails app found at: #{rails_path}"
+      ENV["RACK_ENV"] ||= ENV["RAILS_ENV"] || "development"
+      require rails_path
+      ::Rails.application.eager_load!
+      true
+    else
+      require rails_path
+    end
+  end
+
+  # Loads Rails app at `root` if `CarrotRpc.configuration.autoload_rails`
+  #
+  # @param (see load_root)
+  # @return (see load_root)
+  # @raise (see load_root)
+  def self.conditionally_load_root(root, logger:)
+    if CarrotRpc.configuration.autoload_rails
+      load_root(root, logger: logger)
+    end
+  end
+end

--- a/lib/carrot_rpc/server_runner/logger.rb
+++ b/lib/carrot_rpc/server_runner/logger.rb
@@ -1,0 +1,31 @@
+# Constructs a logger based on the {CarrotRpc.configuration} and Rails environment
+module CarrotRpc::ServerRunner::Logger
+  # A `Logger` configured based on `CarrotRpc.configuration.logfile` and `CarrotRpc.configuration.loglevel`
+  #
+  # Fallbacks:
+  # * `Rails.logger` if `Rails` is loaded
+  # * `Logger` to `STDOUT` if `Rails` is not loaded
+  #
+  # @return [Logger]
+  def self.configured
+    logger = from_file
+
+    if logger.nil?
+      logger = if defined?(::Rails)
+                 CarrotRpc::TaggedLog.new(logger: Rails.logger, tags: ["Carrot RPC"])
+               else
+                 Logger.new(STDOUT)
+               end
+    end
+
+    logger.level = CarrotRpc.configuration.loglevel
+
+    logger
+  end
+
+  def self.from_file
+    return nil unless CarrotRpc.configuration.logfile
+
+    ::Logger.new(CarrotRpc.configuration.logfile)
+  end
+end

--- a/lib/carrot_rpc/server_runner/pid.rb
+++ b/lib/carrot_rpc/server_runner/pid.rb
@@ -1,0 +1,142 @@
+# Pid and pid path for {CarrotRpc::ServerRunner}
+class CarrotRpc::ServerRunner::Pid
+  # Attributes
+
+  # @return [Logger]
+  attr_reader :logger
+
+  # @return [String]
+  attr_reader :path
+
+  # Methods
+
+  ## Class Methods
+
+  # The status of the given `pid` number.
+  #
+  # @param pid [Integer] a 0 or positive PID
+  # @return [:dead] if `pid` is `0`
+  # @return (see number_error_check_status)
+  def self.number_status(pid)
+    if pid == 0
+      :dead
+    else
+      number_error_check_status(pid)
+    end
+  end
+
+  # The status of the given `non_zero_pid` number.
+  #
+  # @param non_zero_pid [Integer] a non-zero pid
+  # @return [:dead] if `pid` cannot be contacted
+  # @return [:not_owned] if interacting with `pid` raises a permission error
+  # @return [:running] if `pid` is running
+  def self.number_error_check_status(non_zero_pid)
+    # sending signal `0` just performs error checking
+    Process.kill(0, non_zero_pid)
+  rescue Errno::ESRCH
+    # Invalid pid
+    :dead
+  rescue Errno::EPERM
+    # no privilege to interact with process
+    :not_owned
+  else
+    :running
+  end
+
+  # Status of the `pid` inside `path`.
+  #
+  # @return [:exited] if `path` does not exist, which indicates the server never ran or exited cleanly
+  # @return [:not_owned] if `path` cannot be read
+  # @return (see number_status)
+  def self.path_status(path)
+    pid = File.read(path).to_i
+  rescue Errno::ENOENT
+    # File does not exist
+    :exited
+  rescue Errno::EPERM
+    # File cannot be read
+    :not_owned
+  else
+    number_status(pid)
+  end
+
+  ## Initialize
+
+  # @param path [Path, nil] path to pid path
+  def initialize(path:, logger:)
+    unless path.nil?
+      # daemonization will change CWD so expand relative paths now
+      @path = File.expand_path(path)
+    end
+
+    @logger = logger
+  end
+
+  ## Instance Methods
+
+  # Exits if {#status} indicates server is already running, otherwise deletes {#path}.
+  #
+  # @return [void]
+  def check
+    if path?
+      case self.class.path_status(path)
+      when :running, :not_owned
+        logger.warn "A server is already running. Check #{path}"
+        exit(1)
+      when :dead
+        delete
+      end
+    end
+  end
+
+  # Deletes `path` if it is set
+  #
+  # @return [void]
+  def delete
+    if path? && File.exist?(path)
+      File.delete(path)
+    end
+  end
+
+  # Registers an `at_exit` handler to {#delete}.
+  #
+  # @return [void]
+  def delete_at_exit
+    at_exit do
+      delete
+    end
+  end
+
+  # Keeps trying to write {#path} until it succeeds
+  def ensure_written
+    if path?
+      begin
+        write
+      rescue Errno::EEXIST
+        check
+
+        retry
+      else
+        delete_at_exit
+      end
+    end
+  end
+
+  # Whether {#path} is set.
+  #
+  # @return [true] if {#path} is not `nil`.
+  # @return [false] otherwise
+  def path?
+    !path.nil?
+  end
+
+  # Write to process id path
+  #
+  # @return [void]
+  def write
+    File.open(path, File::CREAT | File::EXCL | File::WRONLY) do |f|
+      f.write(Process.pid.to_s)
+    end
+  end
+end

--- a/lib/carrot_rpc/server_runner/signals.rb
+++ b/lib/carrot_rpc/server_runner/signals.rb
@@ -1,0 +1,21 @@
+# Traps all {the signals NAMES} that should be intercepted by a long-running background process.
+module CarrotRpc::ServerRunner::Signals
+  # CONSTANTS
+
+  # The name of the signals to trap.
+  NAMES = %w(HUP INT QUIT TERM).freeze
+
+  # Traps all {NAMES}.
+  #
+  # @yield [name] Block to call when the signal is trapped.
+  # @yieldparam name [String] the name of the signal that was trapped
+  # @yieldreturn [void]
+  # @return [void]
+  def self.trap
+    NAMES.each do |name|
+      Kernel.trap(name) do
+        yield name
+      end
+    end
+  end
+end

--- a/lib/carrot_rpc/tagged_log.rb
+++ b/lib/carrot_rpc/tagged_log.rb
@@ -2,7 +2,7 @@
 class CarrotRpc::TaggedLog
   attr_reader :logger, :tags
 
-  def initialize(logger: , tags:)
+  def initialize(logger:, tags:)
     @logger = logger
     @tags = *tags
   end

--- a/lib/carrot_rpc/tagged_log.rb
+++ b/lib/carrot_rpc/tagged_log.rb
@@ -8,7 +8,7 @@ class CarrotRpc::TaggedLog
   end
 
   # Dyanmically define logger methods with a tagged reference. Makes filtering of logs possible.
-  %i(debug info warn error fatal uknown).each do |level|
+  %i(debug info warn error fatal unknown).each do |level|
     define_method(level) do |msg|
       logger.tagged(tags) { logger.send(level, msg) }
     end

--- a/lib/carrot_rpc/tagged_log.rb
+++ b/lib/carrot_rpc/tagged_log.rb
@@ -7,6 +7,14 @@ class CarrotRpc::TaggedLog
     @tags = *tags
   end
 
+  def level
+    logger.level
+  end
+
+  def level=(level)
+    logger.level = level
+  end
+
   # Dyanmically define logger methods with a tagged reference. Makes filtering of logs possible.
   %i(debug info warn error fatal unknown).each do |level|
     define_method(level) do |msg|

--- a/lib/carrot_rpc/tagged_log.rb
+++ b/lib/carrot_rpc/tagged_log.rb
@@ -1,19 +1,16 @@
-# Library for standardizing the RabbitMQ RPC workflow.
-module CarrotRpc
-  # Wrap the Logger object with convenience methods.
-  class TaggedLog
-    attr_reader :logger, :tags
+# Wrap the Logger object with convenience methods.
+class CarrotRpc::TaggedLog
+  attr_reader :logger, :tags
 
-    def initialize(logger: , tags:)
-      @logger = logger
-      @tags = *tags
-    end
+  def initialize(logger: , tags:)
+    @logger = logger
+    @tags = *tags
+  end
 
-    # Dyanmically define logger methods with a tagged reference. Makes filtering of logs possible.
-    %i(debug info warn error fatal uknown).each do |level|
-      define_method(level) do |msg|
-        logger.tagged(tags) { logger.send(level, msg) }
-      end
+  # Dyanmically define logger methods with a tagged reference. Makes filtering of logs possible.
+  %i(debug info warn error fatal uknown).each do |level|
+    define_method(level) do |msg|
+      logger.tagged(tags) { logger.send(level, msg) }
     end
   end
 end

--- a/lib/carrot_rpc/version.rb
+++ b/lib/carrot_rpc/version.rb
@@ -1,3 +1,3 @@
 module CarrotRpc
-  VERSION = "0.1.2"
+  VERSION = "0.1.2".freeze
 end

--- a/lib/carrot_rpc/version.rb
+++ b/lib/carrot_rpc/version.rb
@@ -1,3 +1,3 @@
 module CarrotRpc
-  VERSION = "0.1.2".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/spec/carrot_rpc/carrot_rpc_spec.rb
+++ b/spec/carrot_rpc/carrot_rpc_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "carrot_rpc"
 
-describe CarrotRpc do
+RSpec.describe CarrotRpc do
   it "has a configuration object" do
     expect(CarrotRpc.configuration).to be_an_instance_of(CarrotRpc::Configuration)
   end

--- a/spec/carrot_rpc/cli_spec.rb
+++ b/spec/carrot_rpc/cli_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe CarrotRpc::CLI do
   subject { CarrotRpc::CLI }
 
   describe "runloop sleep" do
-    before(:each) { expect(CarrotRpc.configuration).to receive_message_chain("runloop_sleep=").with(10) }
+    before(:each) do
+      expect(CarrotRpc.configuration).to receive_message_chain("runloop_sleep=").with(10)
+    end
 
     it "sets the sleep value with long switch" do
       CarrotRpc::CLI.parse_options(["--runloop_sleep=10"])
@@ -17,7 +19,9 @@ RSpec.describe CarrotRpc::CLI do
   end
 
   describe "daemonize" do
-    before(:each) { expect(CarrotRpc.configuration).to receive("daemonize=").with(true) }
+    before(:each) do
+      expect(CarrotRpc.configuration).to receive("daemonize=").with(true)
+    end
 
     it "sets daemonize value with long swtich" do
       CarrotRpc::CLI.parse_options(["--daemonize"])

--- a/spec/carrot_rpc/cli_spec.rb
+++ b/spec/carrot_rpc/cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'carrot_rpc'
 require 'carrot_rpc/cli'
 
-describe CarrotRpc::CLI do
+RSpec.describe CarrotRpc::CLI do
   subject { CarrotRpc::CLI }
 
   describe 'runloop sleep' do

--- a/spec/carrot_rpc/cli_spec.rb
+++ b/spec/carrot_rpc/cli_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe CarrotRpc::CLI do
     end
   end
 
-
   describe 'daemonize' do
     before(:each) { expect(CarrotRpc.configuration).to receive('daemonize=').with(true) }
 

--- a/spec/carrot_rpc/cli_spec.rb
+++ b/spec/carrot_rpc/cli_spec.rb
@@ -1,40 +1,40 @@
-require 'spec_helper'
-require 'carrot_rpc'
-require 'carrot_rpc/cli'
+require "spec_helper"
+require "carrot_rpc"
+require "carrot_rpc/cli"
 
 RSpec.describe CarrotRpc::CLI do
   subject { CarrotRpc::CLI }
 
-  describe 'runloop sleep' do
-    before(:each) { expect(CarrotRpc.configuration).to receive_message_chain('runloop_sleep=').with(10) }
+  describe "runloop sleep" do
+    before(:each) { expect(CarrotRpc.configuration).to receive_message_chain("runloop_sleep=").with(10) }
 
-    it 'sets the sleep value with long switch' do
+    it "sets the sleep value with long switch" do
       CarrotRpc::CLI.parse_options(["--runloop_sleep=10"])
     end
-    it 'sets the sleep value with short switch' do
+    it "sets the sleep value with short switch" do
       CarrotRpc::CLI.parse_options(["-s", "10"])
     end
   end
 
-  describe 'daemonize' do
-    before(:each) { expect(CarrotRpc.configuration).to receive('daemonize=').with(true) }
+  describe "daemonize" do
+    before(:each) { expect(CarrotRpc.configuration).to receive("daemonize=").with(true) }
 
-    it 'sets daemonize value with long swtich' do
+    it "sets daemonize value with long swtich" do
       CarrotRpc::CLI.parse_options(["--daemonize"])
     end
 
-    it 'sets daemonize value with short switch' do
+    it "sets daemonize value with short switch" do
       CarrotRpc::CLI.parse_options(["-d"])
     end
   end
 
-  it 'sets pid value with long swtich' do
-    expect(CarrotRpc.configuration).to receive('pidfile=').with("snarg")
+  it "sets pid value with long swtich" do
+    expect(CarrotRpc.configuration).to receive("pidfile=").with("snarg")
     CarrotRpc::CLI.parse_options(["--pid=snarg"])
   end
 
-  it 'sets autoload_rails value with long swtich' do
-    expect(CarrotRpc.configuration).to receive('autoload_rails=')
+  it "sets autoload_rails value with long swtich" do
+    expect(CarrotRpc.configuration).to receive("autoload_rails=")
     CarrotRpc::CLI.parse_options(["--autoload_rails=false"])
   end
 

--- a/spec/carrot_rpc/configuration_spec.rb
+++ b/spec/carrot_rpc/configuration_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "carrot_rpc/configuration"
 
-describe CarrotRpc::Configuration do
+RSpec.describe CarrotRpc::Configuration do
   subject { CarrotRpc::Configuration.new }
 
   it 'defaults daemonize' do

--- a/spec/carrot_rpc/configuration_spec.rb
+++ b/spec/carrot_rpc/configuration_spec.rb
@@ -4,19 +4,19 @@ require "carrot_rpc/configuration"
 RSpec.describe CarrotRpc::Configuration do
   subject { CarrotRpc::Configuration.new }
 
-  it 'defaults daemonize' do
+  it "defaults daemonize" do
     expect(subject.daemonize).to eq false
   end
 
-  it 'defaults pidfile' do
+  it "defaults pidfile" do
     expect(subject.pidfile).to eq nil
   end
 
-  it 'defaults runloop sleep' do
+  it "defaults runloop sleep" do
     expect(subject.runloop_sleep).to eq 0
   end
 
-  it 'defaults to load rails' do
+  it "defaults to load rails" do
     expect(subject.autoload_rails).to eq true
   end
 

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -14,7 +14,7 @@ describe CarrotRpc::RpcClient do
 
     it "has a queue name class method" do
       CarrotRpc::RpcClient.queue_name "foo"
-      expect(CarrotRpc::RpcClient.get_queue_name).to eq "foo"
+      expect(CarrotRpc::RpcClient.queue_name).to eq "foo"
       # reset state
       CarrotRpc::RpcClient.queue_name nil
     end

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -2,61 +2,128 @@ require "spec_helper"
 require "carrot_rpc"
 
 RSpec.describe CarrotRpc::RpcClient do
-  subject { CarrotRpc::RpcClient.new }
+  subject(:client) {
+    client_class.new
+  }
+
+  let(:client_class) {
+    Class.new(CarrotRpc::RpcClient)
+  }
 
   describe "#queue_name" do
-    before :each do
-      @channel = double("channel", close: true, queue: true, default_exchange: true)
-      @bunny = double("bunny", close: true, create_channel: @channel)
-
-      allow_any_instance_of(CarrotRpc::Configuration).to receive(:bunny) { @bunny }
-    end
-
     it "has a queue name class method" do
-      CarrotRpc::RpcClient.queue_name "foo"
-      expect(CarrotRpc::RpcClient.queue_name).to eq "foo"
-      # reset state
-      CarrotRpc::RpcClient.queue_name nil
+      client_class.queue_name "foo"
+      expect(client_class.queue_name).to eq "foo"
     end
 
-    it "does not default queue name" do
-      expect(@channel).to receive(:queue).with(nil, auto_delete: false)
-      subject
+    context "during #initialize" do
+      # lets
+
+      let(:channel) {
+        instance_double(Bunny::Channel, default_exchange: nil)
+      }
+
+      # Callbacks
+
+      before(:each) do
+        allow(CarrotRpc.configuration.bunny).to receive(:create_channel).and_return(channel)
+      end
+
+      it "does not default queue name" do
+        expect(channel).to receive(:queue).with(nil, auto_delete: false)
+
+        client
+      end
     end
   end
 
   describe "#start" do
-    after :each do
-      server.channel.close
-      subject.channel.close
+    # Methods
+
+    def delete_queue
+      channel = CarrotRpc.configuration.bunny.create_channel
+      queue = channel.queue("foo")
+      queue.delete
+      channel.close
     end
 
-    subject do
-      CarrotRpc::RpcClient.queue_name "foo"
-      CarrotRpc::RpcClient.new
-    end
+    # lets
 
-    let(:server) do
-      CarrotRpc::RpcServer.queue_name "foo"
-      CarrotRpc::RpcServer.class_eval do
+    let(:client) {
+      client_class.new
+    }
+
+    let(:client_class) {
+      Class.new(CarrotRpc::RpcClient) do
+        queue_name "foo"
+      end
+    }
+
+    let(:server) {
+      server_class.new(block: false)
+    }
+
+    let(:server_class) {
+      Class.new(CarrotRpc::RpcServer) do
+        queue_name "foo"
+
+        # Instance Methods
+
         def show(_params)
-          { "foo-baz" => { "fizz-buzz" => "baz", "foo-bar" => "biz",
-                           "biz-baz" => { "super-duper" => "grovy" } } }
+          {
+            "foo-baz" => {
+              "biz-baz" => {
+                "super-duper" => "grovy"
+              },
+              "fizz-buzz" => "baz",
+              "foo-bar" => "biz"
+            }
+          }
         end
       end
+    }
 
-      CarrotRpc::RpcServer.new(block: false)
-    end
+    # Callbacks
 
-    let(:result) do
-      { "foo_baz" => { "fizz_buzz" => "baz", "foo_bar" => "biz",
-                       "biz_baz" => { "super_duper" => "grovy" } } }
-    end
+    before(:each) do
+      # Delete queue if another test did not clean up properly, such as due to interrupt
+      delete_queue
 
-    it "parses the payload from json to hash and changes '-' to '_' in the keys" do
-      subject.start
       server.start
-      expect(subject.show({})).to eq result
+    end
+
+    after(:each) do
+      client.channel.close
+      server.channel.close
+
+      # Clean up properly
+      delete_queue
+    end
+
+    context "with client started" do
+      # lets
+
+      let(:result) do
+        {
+          "foo_baz" => {
+            "biz_baz" => {
+              "super_duper" => "grovy"
+            },
+            "fizz_buzz" => "baz",
+            "foo_bar" => "biz"
+          }
+        }
+      end
+
+      # Callbacks
+
+      before(:each) do
+        client.start
+      end
+
+      it "parses the payload from json to hash and changes '-' to '_' in the keys" do
+        expect(client.show({})).to eq result
+      end
     end
   end
 end

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'carrot_rpc'
 
-describe CarrotRpc::RpcClient do
+RSpec.describe CarrotRpc::RpcClient do
   subject { CarrotRpc::RpcClient.new }
 
   describe "#queue_name" do

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'carrot_rpc'
+require "spec_helper"
+require "carrot_rpc"
 
 RSpec.describe CarrotRpc::RpcClient do
   subject { CarrotRpc::RpcClient.new }
@@ -32,16 +32,16 @@ RSpec.describe CarrotRpc::RpcClient do
     end
 
     subject do
-      CarrotRpc::RpcClient.queue_name 'foo'
+      CarrotRpc::RpcClient.queue_name "foo"
       CarrotRpc::RpcClient.new
     end
 
     let(:server) do
-      CarrotRpc::RpcServer.queue_name 'foo'
+      CarrotRpc::RpcServer.queue_name "foo"
       CarrotRpc::RpcServer.class_eval do
         def show(_params)
-          { 'foo-baz' => { 'fizz-buzz' => 'baz', 'foo-bar' => 'biz',
-                           'biz-baz' => { 'super-duper' => 'grovy' } } }
+          { "foo-baz" => { "fizz-buzz" => "baz", "foo-bar" => "biz",
+                           "biz-baz" => { "super-duper" => "grovy" } } }
         end
       end
 
@@ -49,8 +49,8 @@ RSpec.describe CarrotRpc::RpcClient do
     end
 
     let(:result) do
-      { 'foo_baz' => { 'fizz_buzz' => 'baz', 'foo_bar' => 'biz',
-                       'biz_baz' => { 'super_duper' => 'grovy' } } }
+      { "foo_baz" => { "fizz_buzz" => "baz", "foo_bar" => "biz",
+                       "biz_baz" => { "super_duper" => "grovy" } } }
     end
 
     it "parses the payload from json to hash and changes '-' to '_' in the keys" do

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -39,7 +39,7 @@ describe CarrotRpc::RpcClient do
     let(:server) do
       CarrotRpc::RpcServer.queue_name 'foo'
       CarrotRpc::RpcServer.class_eval do
-        def show(params)
+        def show(_params)
           { 'foo-baz' => { 'fizz-buzz' => 'baz', 'foo-bar' => 'biz',
                            'biz-baz' => { 'super-duper' => 'grovy' } } }
         end

--- a/spec/carrot_rpc/rpc_server_spec.rb
+++ b/spec/carrot_rpc/rpc_server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'carrot_rpc'
 
-describe CarrotRpc::RpcServer do
+RSpec.describe CarrotRpc::RpcServer do
   describe "#queue_name" do
     before :each do
       @channel = double("channel", close: true, queue: true, default_exchange: true)

--- a/spec/carrot_rpc/rpc_server_spec.rb
+++ b/spec/carrot_rpc/rpc_server_spec.rb
@@ -13,7 +13,7 @@ describe CarrotRpc::RpcServer do
 
     it "has a queue name class method" do
       CarrotRpc::RpcServer.queue_name "foo"
-      expect(CarrotRpc::RpcServer.get_queue_name).to eq "foo"
+      expect(CarrotRpc::RpcServer.queue_name).to eq "foo"
       # reset state
       CarrotRpc::RpcServer.queue_name nil
     end

--- a/spec/carrot_rpc/rpc_server_spec.rb
+++ b/spec/carrot_rpc/rpc_server_spec.rb
@@ -3,57 +3,107 @@ require "carrot_rpc"
 
 RSpec.describe CarrotRpc::RpcServer do
   describe "#queue_name" do
-    before :each do
-      @channel = double("channel", close: true, queue: true, default_exchange: true)
-      @bunny = double("bunny", close: true, create_channel: @channel)
+    let(:server_class) {
+      Class.new(CarrotRpc::RpcServer)
+    }
 
-      config = instance_double(CarrotRpc::Configuration, bunny: @bunny, logger: @logger)
-      allow(CarrotRpc::Configuration).to receive(:new) { config }
-    end
-
-    it "has a queue name class method" do
-      CarrotRpc::RpcServer.queue_name "foo"
-      expect(CarrotRpc::RpcServer.queue_name).to eq "foo"
-      # reset state
-      CarrotRpc::RpcServer.queue_name nil
+    it "is readable by queue_name/0" do
+      server_class.queue_name "foo"
+      expect(server_class.queue_name).to eq "foo"
     end
   end
 
   describe "#start" do
-    after :each do
-      client.channel.close
-      subject.channel.close
+    # Methods
+
+    def delete_queue
+      channel = CarrotRpc.configuration.bunny.create_channel
+      queue = channel.queue("foo")
+      queue.delete
+      channel.close
     end
 
-    subject do
-      CarrotRpc::RpcServer.queue_name "foo"
-      CarrotRpc::RpcServer.class_eval do
+    # lets
+
+    let(:client_class) {
+      Class.new(CarrotRpc::RpcClient) do
+        queue_name "foo"
+      end
+    }
+
+    let(:client) do
+      client_class.new
+    end
+
+    let(:server_class) {
+      Class.new(CarrotRpc::RpcServer) do
+        queue_name "foo"
+
+        # Instance Methods
+
         def create(params)
           params
         end
       end
+    }
 
-      CarrotRpc::RpcServer.new(block: false)
-    end
+    let(:server) {
+      server_class.new(block: false)
+    }
 
-    let(:client) do
-      CarrotRpc::RpcClient.queue_name "foo"
-      CarrotRpc::RpcClient.new
-    end
+    # Callbacks
 
-    let(:payload) do
-      { "foo-baz" => { "fizz-buzz" => "baz", "foo-bar" => "biz",
-                       "biz-baz" => { "super-duper" => "grovy" } } }
-    end
-    let(:result) do
-      { "foo_baz" => { "fizz_buzz" => "baz", "foo_bar" => "biz",
-                       "biz_baz" => { "super_duper" => "grovy" } } }
-    end
+    before(:each) do
+      # Delete queue if another test did not clean up properly, such as due to interrupt
+      delete_queue
 
-    it "parses the payload from json to hash and changes '-' to '_' in the keys" do
       client.start
-      subject.start
-      expect(client.create(payload)).to eq result
+    end
+
+    after(:each) do
+      client.channel.close
+      server.channel.close
+
+      # Clean up properly
+      delete_queue
+    end
+
+    context "with server started" do
+      # lets
+
+      let(:payload) do
+        {
+          "foo-baz" => {
+            "biz-baz" => {
+              "super-duper" => "grovy"
+            },
+            "fizz-buzz" => "baz",
+            "foo-bar" => "biz"
+          }
+        }
+      end
+
+      let(:result) do
+        {
+          "foo_baz" => {
+            "biz_baz" => {
+              "super_duper" => "grovy"
+            },
+            "fizz_buzz" => "baz",
+            "foo_bar" => "biz"
+          }
+        }
+      end
+
+      # Callbacks
+
+      before(:each) do
+        server.start
+      end
+
+      it "parses the payload from json to hash and changes '-' to '_' in the keys" do
+        expect(client.create(payload)).to eq result
+      end
     end
   end
 end

--- a/spec/carrot_rpc/rpc_server_spec.rb
+++ b/spec/carrot_rpc/rpc_server_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'carrot_rpc'
+require "spec_helper"
+require "carrot_rpc"
 
 RSpec.describe CarrotRpc::RpcServer do
   describe "#queue_name" do
@@ -26,7 +26,7 @@ RSpec.describe CarrotRpc::RpcServer do
     end
 
     subject do
-      CarrotRpc::RpcServer.queue_name 'foo'
+      CarrotRpc::RpcServer.queue_name "foo"
       CarrotRpc::RpcServer.class_eval do
         def create(params)
           params
@@ -37,17 +37,17 @@ RSpec.describe CarrotRpc::RpcServer do
     end
 
     let(:client) do
-      CarrotRpc::RpcClient.queue_name 'foo'
+      CarrotRpc::RpcClient.queue_name "foo"
       CarrotRpc::RpcClient.new
     end
 
     let(:payload) do
-      { 'foo-baz' => { 'fizz-buzz' => 'baz', 'foo-bar' => 'biz',
-                       'biz-baz' => { 'super-duper' => 'grovy' } } }
+      { "foo-baz" => { "fizz-buzz" => "baz", "foo-bar" => "biz",
+                       "biz-baz" => { "super-duper" => "grovy" } } }
     end
     let(:result) do
-      { 'foo_baz' => { 'fizz_buzz' => 'baz', 'foo_bar' => 'biz',
-                       'biz_baz' => { 'super_duper' => 'grovy' } } }
+      { "foo_baz" => { "fizz_buzz" => "baz", "foo_bar" => "biz",
+                       "biz_baz" => { "super_duper" => "grovy" } } }
     end
 
     it "parses the payload from json to hash and changes '-' to '_' in the keys" do

--- a/spec/carrot_rpc/server_runner/autoload_rails_spec.rb
+++ b/spec/carrot_rpc/server_runner/autoload_rails_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe CarrotRpc::ServerRunner::AutoloadRails do
+  context ".load_root" do
+    subject(:load_root) {
+      described_class.load_root(
+        root,
+        logger: logger
+      )
+    }
+
+    let(:logger) {
+      instance_double(Logger, info: nil)
+    }
+
+    context "with valid root" do
+      let(:root) {
+        File.expand_path("../../../dummy", __FILE__)
+      }
+
+      it "returns true" do
+        expect(load_root).to eq true
+      end
+    end
+
+    context "without valid root" do
+      let(:root) {
+        File.expand_path("../../foo", __FILE__)
+      }
+
+      it "raises LoadError" do
+        expect {
+          load_root
+        }.to raise_error(LoadError)
+      end
+    end
+  end
+end

--- a/spec/carrot_rpc/server_runner/pid_spec.rb
+++ b/spec/carrot_rpc/server_runner/pid_spec.rb
@@ -1,0 +1,138 @@
+require "spec_helper"
+
+RSpec.describe CarrotRpc::ServerRunner::Pid do
+  subject(:pid) {
+    described_class.new(path: path, logger: logger)
+  }
+
+  let(:logger) {
+    instance_double(Logger)
+  }
+
+  context "#check" do
+    subject(:check) {
+      pid.check
+    }
+
+    # lets
+
+    let(:path) {
+      "/dev/null"
+    }
+
+    let(:logger) {
+      instance_double(Logger)
+    }
+
+    it "exits when there's an running pid and logs error" do
+      allow(described_class).to receive(:path_status).with(path).and_return(:running)
+      expect(logger).to receive(:warn).with("A server is already running. Check #{path}")
+
+      expect {
+        check
+      }.to terminate.with_code 1
+    end
+
+    it "exits when there's a not_owned pid and logs error" do
+      allow(described_class).to receive(:path_status).with(path).and_return(:not_owned)
+      expect(logger).to receive(:warn).with("A server is already running. Check #{path}")
+
+      expect {
+        check
+      }.to terminate.with_code 1
+    end
+
+    it "removes the path when process is dead" do
+      allow(described_class).to receive(:path_status).with(path).and_return(:dead)
+      expect(pid).to receive(:delete)
+
+      check
+    end
+  end
+
+  context ".path_status" do
+    subject(:path_status) {
+      described_class.path_status(path)
+    }
+
+    # lets
+
+    let(:path) {
+      File.expand_path("../../../dummy/tmp/pids/#{pid_name}", __FILE__)
+    }
+
+    context "path doesn't exist" do
+      let(:pid_name) {
+        "foo.pid"
+      }
+
+      it "returns :exited" do
+        expect(path_status).to eq :exited
+      end
+    end
+
+    context "path exists but is terminated" do
+      let(:pid_name) {
+        "dead.pid"
+      }
+
+      it "returns :dead" do
+        expect(path_status).to eq :dead
+      end
+    end
+
+    context "path exists and is running" do
+      # lets
+
+      let(:pid_name) {
+        "running.pid"
+      }
+
+      # Callbacks
+
+      before(:each) do
+        pid.ensure_written
+      end
+
+      after(:each) do
+        File.delete path
+      end
+
+      it "returns :running" do
+        expect(path_status).to eq :running
+      end
+    end
+  end
+
+  context "#write" do
+    subject(:write) {
+      pid.write
+    }
+
+    # lets
+
+    let(:path) {
+      File.expand_path("../../../dummy/tmp/pids/#{pid_name}", __FILE__)
+    }
+
+    let(:pid_name) {
+      "running.pid"
+    }
+
+    # Callbacks
+
+    after(:each) do
+      File.delete path
+    end
+
+    it "creates a pidfile for a running process" do
+      expect {
+        write
+      }.to change {
+        File.exist? path
+      }.to(true)
+
+      expect(File.read(path).to_i).not_to eq(0)
+    end
+  end
+end

--- a/spec/carrot_rpc/server_runner_spec.rb
+++ b/spec/carrot_rpc/server_runner_spec.rb
@@ -3,7 +3,7 @@ require 'carrot_rpc/server_runner'
 
 RSpec.describe CarrotRpc::ServerRunner do
   let(:args) { { rails_path: File.expand_path("../../dummy", __FILE__) } }
-  subject{ CarrotRpc::ServerRunner.new(**args) }
+  subject { CarrotRpc::ServerRunner.new(**args) }
 
   before :each do
     @logger = instance_double(Logger, info: "", warn: "")
@@ -54,13 +54,13 @@ RSpec.describe CarrotRpc::ServerRunner do
     it "exits when there's an running pid and logs error" do
       allow_any_instance_of(CarrotRpc::ServerRunner).to receive(:pid_status) { :running }
       expect(@logger).to receive(:warn)
-      expect{ subject.check_pid }.to terminate.with_code 1
+      expect { subject.check_pid }.to terminate.with_code 1
     end
 
     it "exits when there's a not_owned pid and logs error" do
       allow_any_instance_of(CarrotRpc::ServerRunner).to receive(:pid_status) { :not_owned }
       expect(@logger).to receive(:warn)
-      expect{ subject.check_pid }.to terminate.with_code 1
+      expect { subject.check_pid }.to terminate.with_code 1
     end
 
     it "removes the file when process is dead" do
@@ -73,7 +73,7 @@ RSpec.describe CarrotRpc::ServerRunner do
 
   describe "#pid_status" do
     let(:pid_name) { "foo.pid" }
-    let(:path) { File.expand_path("../../dummy/tmp/pids/#{pid_name}", __FILE__)}
+    let(:path) { File.expand_path("../../dummy/tmp/pids/#{pid_name}", __FILE__) }
 
     context "file doesn't exist" do
       it "returns exited" do
@@ -101,7 +101,7 @@ RSpec.describe CarrotRpc::ServerRunner do
 
   describe "#write_pid" do
     let(:pid_name) { "running.pid" }
-    let(:path) { File.expand_path("../../dummy/tmp/pids/#{pid_name}", __FILE__)}
+    let(:path) { File.expand_path("../../dummy/tmp/pids/#{pid_name}", __FILE__) }
 
     it "creates a pidfile for a running process" do
       subject.instance_variable_set(:@pidfile, path)
@@ -144,7 +144,7 @@ RSpec.describe CarrotRpc::ServerRunner do
 
     it "rails if the rails app can not be found" do
       path = File.expand_path("../foo", __FILE__)
-      expect{subject.load_rails_app(path)}.to raise_error LoadError
+      expect { subject.load_rails_app(path) }.to raise_error LoadError
     end
   end
 
@@ -154,14 +154,14 @@ RSpec.describe CarrotRpc::ServerRunner do
     end
 
     context "with true" do
-      let(:args){ { rails_path: File.expand_path("../../dummy", __FILE__), daemonize: true } }
+      let(:args) { { rails_path: File.expand_path("../../dummy", __FILE__), daemonize: true } }
       it "true when set" do
         expect(subject.daemonize?).to eq true
       end
     end
 
     context "with false" do
-      let(:args){ { rails_path: File.expand_path("../../dummy", __FILE__), daemonize: false } }
+      let(:args) { { rails_path: File.expand_path("../../dummy", __FILE__), daemonize: false } }
 
       it "false when set" do
         expect(subject.daemonize?).to eq false
@@ -232,7 +232,7 @@ RSpec.describe CarrotRpc::ServerRunner do
   end
 
   describe "#set_logger" do
-    let(:args) { {rails_path: nil } }
+    let(:args) { { rails_path: nil } }
     before :each do
       CarrotRpc.configuration.autoload_rails = false
     end
@@ -246,7 +246,7 @@ RSpec.describe CarrotRpc::ServerRunner do
         CarrotRpc::CLI.parse_options(["--logfile=../rpc.log"])
         logger = instance_double(Logger, level: 1)
         expect(logger).to receive(:level=)
-        expect(Logger).to receive(:new).with(CarrotRpc.configuration.logfile){ logger }
+        expect(Logger).to receive(:new).with(CarrotRpc.configuration.logfile) { logger }
         subject.send(:set_logger)
       end
 

--- a/spec/carrot_rpc/server_runner_spec.rb
+++ b/spec/carrot_rpc/server_runner_spec.rb
@@ -217,12 +217,12 @@ RSpec.describe CarrotRpc::ServerRunner do
 
   describe "#run_servers" do
     before :all do
-      path = $:.first
-      $:.unshift([path, "dummy", "app", "servers"].join("/"))
+      path = $LOAD_PATH.first
+      $LOAD_PATH.unshift([path, "dummy", "app", "servers"].join("/"))
     end
 
     after :all do
-      $:.shift
+      $LOAD_PATH.shift
     end
 
     it "loads the servers" do

--- a/spec/carrot_rpc/server_runner_spec.rb
+++ b/spec/carrot_rpc/server_runner_spec.rb
@@ -65,7 +65,6 @@ describe CarrotRpc::ServerRunner do
 
     it "removes the file when process is dead" do
       allow_any_instance_of(CarrotRpc::ServerRunner).to receive(:pid_status) { :dead }
-      file = double(File, delete: "")
       allow(File).to receive(:delete)
       expect(File).to receive(:delete)
       subject.check_pid

--- a/spec/carrot_rpc/server_runner_spec.rb
+++ b/spec/carrot_rpc/server_runner_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'carrot_rpc/server_runner'
+require "spec_helper"
+require "carrot_rpc/server_runner"
 
 RSpec.describe CarrotRpc::ServerRunner do
   let(:args) { { rails_path: File.expand_path("../../dummy", __FILE__) } }
@@ -35,7 +35,7 @@ RSpec.describe CarrotRpc::ServerRunner do
 
     context "passing params" do
       let(:args) do
-        { rails_path: File.expand_path("../../dummy", __FILE__), pidfile: 'foo', runloop_sleep: 5, daemonize: true }
+        { rails_path: File.expand_path("../../dummy", __FILE__), pidfile: "foo", runloop_sleep: 5, daemonize: true }
       end
 
       it "sets instance vars to the params passed" do

--- a/spec/carrot_rpc/server_runner_spec.rb
+++ b/spec/carrot_rpc/server_runner_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'carrot_rpc/server_runner'
 
-describe CarrotRpc::ServerRunner do
+RSpec.describe CarrotRpc::ServerRunner do
   let(:args) { { rails_path: File.expand_path("../../dummy", __FILE__) } }
   subject{ CarrotRpc::ServerRunner.new(**args) }
 

--- a/spec/dummy/app/servers/foo_server.rb
+++ b/spec/dummy/app/servers/foo_server.rb
@@ -2,7 +2,6 @@ class FooServer
   attr_accessor :logger
 
   def initialize(block: false)
-
   end
 
   def start

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,11 +1,26 @@
+# standard library
+require "stringio"
+
+# gems
+require "active_support/logger"
+require "active_support/tagged_logging"
+
 # Fake rails environment config
-class Rails
+module Rails
+  class << self
+    attr_accessor :logger_string_io
+  end
+
   def self.application
     Application
   end
 
   def self.logger
-    Logger.new(STDOUT)
+    @logger ||= ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(logger_string_io))
+  end
+
+  def self.logger_string_io
+    @logger_string_io ||= StringIO.new
   end
 
   class Application

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@
 
 require "byebug"
 # support files
-Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.before(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,9 @@
 
 require "byebug"
 # support files
-Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each do |f|
+  require f
+end
 
 RSpec.configure do |config|
   config.before(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each do |f|
   require f
 end
 
+require "carrot_rpc"
+
 RSpec.configure do |config|
   config.before(:suite) do
     # Remove the log file on each run.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,11 +51,11 @@ RSpec.configure do |config|
     File.delete(log_file) if File.exist?(log_file)
 
     # Setup the connection to RabbitMQ
-    CarrotRpc.configure do |config|
+    CarrotRpc.configure do |carrot_rpc_config|
       bunny = Bunny.new
       bunny.start
-      config.bunny = bunny
-      config.logger = Logger.new(log_file)
+      carrot_rpc_config.bunny = bunny
+      carrot_rpc_config.logger = Logger.new(log_file)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,29 +22,6 @@ require "byebug"
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  # rspec-expectations config goes here. You can use an alternate
-  # assertion/expectation library such as wrong or the stdlib/minitest
-  # assertions if you prefer.
-  config.expect_with :rspec do |expectations|
-    # This option will default to `true` in RSpec 4. It makes the `description`
-    # and `failure_message` of custom matchers include text for helper methods
-    # defined using `chain`, e.g.:
-    #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
-    # ...rather than:
-    #     # => "be bigger than 2"
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end
-
-  # rspec-mocks config goes here. You can use an alternate test double
-  # library (such as bogus or mocha) by changing the `mock_with` option here.
-  config.mock_with :rspec do |mocks|
-    # Prevents you from mocking or stubbing a method that does not exist on
-    # a real object. This is generally recommended, and will default to
-    # `true` in RSpec 4.
-    mocks.verify_partial_doubles = true
-  end
-
   config.before(:suite) do
     # Remove the log file on each run.
     log_file = File.expand_path('../../logs/test.log', __FILE__)
@@ -59,21 +36,6 @@ RSpec.configure do |config|
     end
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
@@ -81,9 +43,24 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
@@ -95,21 +72,21 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
+  config.filter_run :focus
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   config.profile_examples = 10
 
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  config.run_all_when_everything_filtered = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.before(:suite) do
     # Remove the log file on each run.
-    log_file = File.expand_path('../../logs/test.log', __FILE__)
+    log_file = File.expand_path("../../logs/test.log", __FILE__)
     File.delete(log_file) if File.exist?(log_file)
 
     # Setup the connection to RabbitMQ
@@ -69,7 +69,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   config.filter_run :focus

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,6 +87,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.order = :random
+
+  Kernel.srand config.seed
+
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     # Remove the log file on each run.
     log_file = File.expand_path('../../logs/test.log', __FILE__)
-    File.delete(log_file) if File.exists?(log_file)
+    File.delete(log_file) if File.exist?(log_file)
 
     # Setup the connection to RabbitMQ
     CarrotRpc.configure do |config|

--- a/spec/support/matchers/terminate.rb
+++ b/spec/support/matchers/terminate.rb
@@ -12,7 +12,7 @@ RSpec::Matchers.define :terminate do |_code|
     rescue SystemExit => e
       actual = e.status
     end
-    actual and actual == status_code
+    actual && actual == status_code
   end
 
   chain :with_code do |status_code|

--- a/spec/support/matchers/terminate.rb
+++ b/spec/support/matchers/terminate.rb
@@ -1,5 +1,5 @@
 # Custom matcher courtesy of https://gist.github.com/mmasashi/58bd7e2668836a387856
-RSpec::Matchers.define :terminate do |code|
+RSpec::Matchers.define :terminate do |_code|
   actual = nil
 
   def supports_block_expectations?
@@ -19,12 +19,12 @@ RSpec::Matchers.define :terminate do |code|
     @status_code = status_code
   end
 
-  failure_message do |block|
+  failure_message do |_block|
     "expected block to call exit(#{status_code}) but exit" +
       (actual.nil? ? " not called" : "(#{actual}) was called")
   end
 
-  failure_message_when_negated do |block|
+  failure_message_when_negated do |_block|
     "expected block not to call exit(#{status_code})"
   end
 


### PR DESCRIPTION
# Changelog
* Enhancements
  * Gems ordered and documented in gemspec and `Gemfile`
  * Temorpary (`#`) files removed from git
  * Rubocop is enabled and used on CircleCI
    * Unused variables are prefixed with `_`
    * `fail` is used instead of `raise` when first raising an exception
    * Remove usage of deprecated methods
    * Print error if `byebug` can't be loaded instead of failing silently, but CLI still starts
    * Stop shadowing outer local variables in blocks
    * Remove unused assignments
    * Set and enforce max line length to 120
    * Use `find` instead of `select {}.first` for better performance
    * `queue_name` will retrieve the current queue name while `queue_name(new_name)` will set it.
    * Align hashes
    * Align parameters
    * Favor symbolic `&&` over `and`. (They have different precedence too)
    * Remove block comments
    * Assign to variable outside conditionals instead of on each branch
    * Remove extra empty lines
    * Don't favor guard clauses as they prevent break pointing the body and guard separately and obscure bodies that don't have code coverage.
    * Remove extra spacing
    * Correct indentation
    * Freeze `CarrotRpc::VERSION` so it is immutable
    * Use `until` instead of negated `while`
    * Use `_` to separate digits in large numerals
    * Use `( )` for sigils
    * Remove redundant `self.` for method calls
    * Use `%r{}` instead of `//` for regexps
    * Use newlines instead of `;`
    * Add spacing around blocks and braces
    * Enforce double quotes for all strings as double quotes work for strings in both Ruby and Elixir. (Single quotes are for Char Lists in Elixir)
    * Use `&:<method>` instead of calling a non-args method in blocks
    * Use `attr_reader` instead of trivial accessor methods
    * Remove unneed interpolation
    * Use double quotes instead of `%q`
    * Use `%w` for word arrays
    * Extract methods to lower to AbcSize metric and Method Length
    * Extract classes and modules to lower Class Length
    * Use `const_get` and `constantize` instead of security risk `eval`
  * Enable all RSpec 3 recommended options
    * Fix order-dependency of specs.
  * Use `autoload` to delay loading
  * Use compact class and module children to prevent parent from being missed when loading.
  * Add `rake spec`
  * Add Luke Imhoff as an author
  * Set gem home page to this repository
  * Semantic block delimiters, so we always think about procedural vs functional blocks to make Elixir coding easier.
* Bug Fixes
  * `ClientServer::ClassMethods` has been moved under `CarrotRpc` namespace as `CarrotRpc::ClientServer`
  * `HashExtensions` has been moved under `CarrotRpc` namespace as `CarrotRpc::HashExtensions`
* Incompatible Changes
  * `ClientServer::ClassMethods` renamed to `CarrotRpc::ClientServer`
  * `HashExtensions` renamed to `CarrotRpc::HashExtensions`
  * `ClientServer::ClassMethods#get_queue_name` renamed to `CarrotRpc::ClientServer#queue_name()` (no args is the reader, one argument is the writer)