### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
 # Changelog
 All significant changes in the project are documented here.
 
+## v0.2.1
+
+### Bug Fixes
+* [#6](https://github.com/C-S-D/carrot_rpc/pull/6) - [shamil614](https://github.com/shamil614)
+  * Error class not loaded in RpcServer
+  * RpcServer should not rename json keys
+  * RpcClient dasherizes keys before serializing hash to json. Better conformity to json property naming conventions.
+  * RpcClient underscores keys after receiving response from server. Better conformity to ruby naming conventions.
+
+
 ## v0.2.0
 
 ### Enhancements

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -50,7 +50,7 @@ class CarrotRpc::RpcClient
   # @return [Object] the result of the method call.
   def remote_call(remote_method, params)
     correlation_id = SecureRandom.uuid
-    publish(correlation_id: correlation_id, method: remote_method, params: params)
+    publish(correlation_id: correlation_id, method: remote_method, params: params.rename_keys("_", "-"))
     wait_for_result(correlation_id)
   end
 

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -1,3 +1,5 @@
+require "carrot_rpc/rpc_server/error"
+
 # Base RPC Server class. Other Servers should inherit from this.
 class CarrotRpc::RpcServer
   using CarrotRpc::HashExtensions
@@ -25,8 +27,7 @@ class CarrotRpc::RpcServer
     @server_queue.subscribe(block: @block) do |_delivery_info, properties, payload|
       logger.debug "Receiving message: #{payload}"
 
-      request_message = JSON.parse(payload).rename_keys("-", "_")
-                            .with_indifferent_access
+      request_message = JSON.parse(payload).with_indifferent_access
 
       process_request(request_message, properties: properties)
     end
@@ -34,7 +35,7 @@ class CarrotRpc::RpcServer
 
   def process_request(request_message, properties:)
     result = send(request_message[:method], request_message[:params])
-  rescue Error => rpc_server_error
+  rescue CarrotRpc::Error => rpc_server_error
     logger.error(rpc_server_error)
 
     reply_error rpc_server_error.serialized_message,

--- a/lib/carrot_rpc/version.rb
+++ b/lib/carrot_rpc/version.rb
@@ -1,3 +1,3 @@
 module CarrotRpc
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end


### PR DESCRIPTION
* Error class not loaded in RpcServer
* RpcServer should not rename json keys
* RpcClient dasherizes keys before serializing hash to json. Better conformity to json property naming conventions.
* RpcClient underscores keys after receiving response from server. Better conformity to ruby naming conventions.