### PR TITLE
Fix rubocop version

### DIFF
--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   # Unit test framework
   spec.add_development_dependency "rspec"
   # Style-checker
-  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop", "~> 0.36.0"
 
   spec.required_ruby_version = "~> 2.2"
 end


### PR DESCRIPTION
# Changelog

## Bug Fixes
* New rubocop versions add new cops or deprecate old config settings, so it is not safe to have `"rubocop"` without a version in the gemspec.