### PR TITLE
VPP-635: Put JSONAPI errors into JSONAPI RPC error

### DIFF
--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -67,7 +67,21 @@ class CarrotRpc::RpcServer
 
   # See http://www.jsonrpc.org/specification#response_object
   def reply_result(result, properties:, request_message:)
-    response_message = { id: request_message[:id], result: result, jsonrpc: "2.0" }
+    if result["errors"]
+      reply_result_with_errors(result, properties: properties, request_message: request_message)
+    else
+      reply_result_without_errors(result, properties: properties, request_message: request_message)
+    end
+  end
+
+  def reply_result_with_errors(result, properties:, request_message:)
+    reply_error({ code: 422, data: result, message: "JSONAPI error" },
+                properties: properties,
+                request_message: request_message)
+  end
+
+  def reply_result_without_errors(result, properties:, request_message:)
+    response_message = { id: request_message[:id], jsonrpc: "2.0", result: result }
 
     logger.debug "Publishing result: #{result} to #{response_message}"
 


### PR DESCRIPTION
# Changelog

## Bug Fixes
* Put JSONAPI errors documents into the JSONRPC error fields instead of returning as normal results as consumers, such as `Rpc.Generic.Client` are expecting all errors to be in JSONRPC's error field and not have to check if the non-error `result` contains a JSONAPI level error.  This achieves parity with the behavior in the Elixir `Rpc.Generic.Server`.
* Scrub JSONAPI error fields that are `nil` so they don't get transmitted as `null`.  JSONAPI spec is quite clear that `null` columns shouldn't be transmitted except in the case of `null` data to signal a missing singleton resource.  This achieves compatibility with the error parsing in `Rpc.Generic.Client` in Elixir.