### PR TITLE
Configurable key formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ CarrotRpc.configure do |config|
   config.before_request = proc { |params| params.merge(foo: "bar") }
   # Number of seconds to wait before a RPC Client request timesout. Default 5 seconds.
   config.rpc_client_timeout = 5
+  # Formats hash keys to stringified and replaces "_" with "-". Default is `:none` for no formatting.
+  config.rpc_client_request_key_format = :dasherize
+  # Formats hash keys to stringified and replaces "-" with "_". Default is `:none` for no formatting.
+  config.rpc_client_response_key_format = :underscore
 
   # Don't use. Server implementation only. The values below are set via CLI:
   # config.pidfile = nil
@@ -166,6 +170,16 @@ class CarsController < ApplicationController
   end
 end
 ```
+
+One way to implement a RpcClient is to override the default configuration.
+```ruby
+config = CarrotRPC.configuration.clone
+# Now only this one object will format keys as dashes
+config.rpc_client_response_key_format = :dasherize
+
+car_client = CarClient.new(config)
+```
+By duplicating the `Configuration` instance you can override the global configuration and pass a custom configuration to the RpcClient instance.
 
 ### Support for JSONAPI::Resources
 In the case that you're writing an application that uses the `jsonapi-resources` gem and you want the `RpcServer` to have the same functionality, then we got you covered. All you need to do is import a few modules. See [jsonapi-resources](https://github.com/cerebris/jsonapi-resources) for details on how to implement resources for your models.

--- a/lib/carrot_rpc.rb
+++ b/lib/carrot_rpc.rb
@@ -18,6 +18,7 @@ module CarrotRpc
   extend ActiveSupport::Autoload
 
   autoload :CLI
+  autoload :ClientActions
   autoload :ClientServer
   autoload :Configuration
   autoload :Error

--- a/lib/carrot_rpc/client_actions.rb
+++ b/lib/carrot_rpc/client_actions.rb
@@ -1,0 +1,34 @@
+# Methods similar to rails controller actions for RpcClient
+module CarrotRpc::ClientActions
+  # Convience method as a resource alias for index action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def index(params)
+    remote_call("index", params)
+  end
+
+  # Convience method as a resource alias for show action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def show(params)
+    remote_call("show", params)
+  end
+
+  # Convience method as a resource alias for create action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def create(params)
+    remote_call("create", params)
+  end
+
+  # Convience method as a resource alias for update action.
+  # To customize, override the method in your class.
+  #
+  # @param params [Hash] the arguments for the method being called.
+  def update(params)
+    remote_call("update", params)
+  end
+end

--- a/lib/carrot_rpc/configuration.rb
+++ b/lib/carrot_rpc/configuration.rb
@@ -1,11 +1,11 @@
 # Global configuration for {CarrotRpc}.  Access with {CarrotRpc.configuration}.
 class CarrotRpc::Configuration
   attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :runloop_sleep, :autoload_rails, :bunny,
-                :before_request, :rpc_client_timeout
+                :before_request, :rpc_client_timeout, :rpc_client_response_key_format, :rpc_client_request_key_format
 
   # logfile - set logger to a file. overrides rails logger.
 
-  def initialize
+  def initialize # rubocop:disable Metrics/MethodLength
     @logfile = nil
     @loglevel = Logger::DEBUG
     @logger = nil
@@ -16,5 +16,7 @@ class CarrotRpc::Configuration
     @bunny = nil
     @before_request = nil
     @rpc_client_timeout = 5
-  end
+    @rpc_client_response_key_format = :none
+    @rpc_client_request_key_format = :none
+  end # rubocop:enable Metrics/MethodLength
 end

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -80,7 +80,7 @@ class CarrotRpc::RpcClient
       response = JSON.parse(payload).with_indifferent_access
 
       result = parse_response(response)
-      result = response_key_formatter(result) if result.is_a? Hash
+      result = response_key_formatter(result).with_indifferent_access if result.is_a? Hash
       @results[properties[:correlation_id]].push(result)
     end
   end

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -9,6 +9,7 @@ class CarrotRpc::RpcClient
   attr_reader :channel, :server_queue, :logger
 
   extend CarrotRpc::ClientServer
+  include CarrotRpc::ClientActions
 
   def self.before_request(*proc)
     if proc.length == 0
@@ -149,38 +150,6 @@ class CarrotRpc::RpcClient
       method:  method,
       params:  params.except(:controller, :action)
     }
-  end
-
-  # Convience method as a resource alias for index action.
-  # To customize, override the method in your class.
-  #
-  # @param params [Hash] the arguments for the method being called.
-  def index(params)
-    remote_call("index", params)
-  end
-
-  # Convience method as a resource alias for show action.
-  # To customize, override the method in your class.
-  #
-  # @param params [Hash] the arguments for the method being called.
-  def show(params)
-    remote_call("show", params)
-  end
-
-  # Convience method as a resource alias for create action.
-  # To customize, override the method in your class.
-  #
-  # @param params [Hash] the arguments for the method being called.
-  def create(params)
-    remote_call("create", params)
-  end
-
-  # Convience method as a resource alias for update action.
-  # To customize, override the method in your class.
-  #
-  # @param params [Hash] the arguments for the method being called.
-  def update(params)
-    remote_call("update", params)
   end
 
   private

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -77,9 +77,10 @@ class CarrotRpc::RpcClient
     # setup subscribe block to Service
     # block => false is a non blocking IO option.
     @reply_queue.subscribe(block: false) do |_delivery_info, properties, payload|
-      response = response_key_formatter(JSON.parse(payload).with_indifferent_access)
+      response = JSON.parse(payload).with_indifferent_access
 
       result = parse_response(response)
+      result = response_key_formatter(result) if result.is_a? Hash
       @results[properties[:correlation_id]].push(result)
     end
   end

--- a/spec/carrot_rpc/configuration_spec.rb
+++ b/spec/carrot_rpc/configuration_spec.rb
@@ -35,4 +35,12 @@ RSpec.describe CarrotRpc::Configuration do
   it "defaults to rpc_client_timeout to 5 seconds" do
     expect(subject.rpc_client_timeout).to eq 5
   end
+
+  it "defaults rpc_client_response_key_format" do
+    expect(subject.rpc_client_response_key_format).to eq :none
+  end
+
+  it "defaults rpc_client_request_key_format" do
+    expect(subject.rpc_client_request_key_format).to eq :none
+  end
 end

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -194,4 +194,101 @@ RSpec.describe CarrotRpc::RpcClient do
       end
     end
   end
+
+  describe "#format_keys" do
+    it "dasherizes the keys" do
+      params = { foo_bar: { "baz_zam" => 1 } }
+      res = described_class.format_keys :dasherize, params
+      expect(res).to eq("foo-bar" => { "baz-zam" => 1 })
+    end
+
+    it "underscores the keys" do
+      params = { "foo-bar" => { "baz-zam" => 1 } }
+      res = described_class.format_keys :underscore, params
+      expect(res).to eq("foo_bar" => { "baz_zam" => 1 })
+    end
+
+    it "skips key formatting for skip" do
+      param_sets = [
+        { "foo-bar" => { "baz-zam" => 1 } },
+        { foo_bar: { "baz_zam" => 1 } },
+        { "foo_bar" => { "baz_zam" => 1 } }
+      ]
+
+      param_sets.each do |params|
+        res = described_class.format_keys :none, params
+        expect(res).to eq(params)
+      end
+    end
+  end
+
+  describe ".response_key_formatter" do
+    before :each do
+      CarrotRpc.configuration.rpc_client_response_key_format = :underscore
+    end
+
+    after :each do
+      CarrotRpc.configuration.rpc_client_response_key_format = :none
+    end
+
+    let(:payload) { { foo: "bar" } }
+
+    context "with a config passed in" do
+      let(:config) do
+        config = CarrotRpc::Configuration.new
+        config.rpc_client_response_key_format = :dasherize
+        config
+      end
+
+      subject { described_class.new(config) }
+
+      it "overwrites the default config" do
+        expect(described_class).to receive(:format_keys).with(:dasherize, payload)
+        subject.response_key_formatter(payload)
+      end
+    end
+
+    context "without a config passed" do
+      subject { described_class.new }
+      it "uses the default config" do
+        expect(described_class).to receive(:format_keys).with(:underscore, payload)
+        subject.response_key_formatter(payload)
+      end
+    end
+  end
+
+  describe ".request_key_formatter" do
+    before :each do
+      CarrotRpc.configuration.rpc_client_request_key_format = :underscore
+    end
+
+    after :each do
+      CarrotRpc.configuration.rpc_client_request_key_format = :none
+    end
+
+    let(:payload) { { foo: "bar" } }
+
+    context "with a config passed in" do
+      let(:config) do
+        config = CarrotRpc::Configuration.new
+        config.rpc_client_request_key_format = :dasherize
+        config
+      end
+
+      subject { described_class.new(config) }
+
+      it "overwrites the default config" do
+        expect(described_class).to receive(:format_keys).with(:dasherize, payload)
+        subject.request_key_formatter(payload)
+      end
+    end
+
+    context "without a config passed" do
+      subject { described_class.new }
+      it "uses the default config" do
+        expect(described_class).to receive(:format_keys).with(:underscore, payload)
+        subject.request_key_formatter(payload)
+      end
+    end
+  end
 end

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -39,8 +39,16 @@ RSpec.describe CarrotRpc::RpcClient do
 
   describe "#remote_call" do
     before :each do
+      CarrotRpc.configuration.rpc_client_request_key_format = :dasherize
+      CarrotRpc.configuration.rpc_client_response_key_format = :underscore
+
       client_class.queue_name "lannister"
       client.start
+    end
+
+    after :each do
+      CarrotRpc.configuration.rpc_client_request_key_format = :none
+      CarrotRpc.configuration.rpc_client_response_key_format = :none
     end
 
     it "calls all the important methods needed for a request" do
@@ -110,7 +118,7 @@ RSpec.describe CarrotRpc::RpcClient do
     end
   end
 
-  describe "#start" do
+  describe "#subscribe" do
     # Methods
 
     def delete_queue
@@ -159,6 +167,7 @@ RSpec.describe CarrotRpc::RpcClient do
     # Callbacks
 
     before(:each) do
+      CarrotRpc.configuration.rpc_client_response_key_format = :underscore
       # Delete queue if another test did not clean up properly, such as due to interrupt
       delete_queue
 
@@ -166,13 +175,21 @@ RSpec.describe CarrotRpc::RpcClient do
     end
 
     after(:each) do
+      CarrotRpc.configuration.rpc_client_response_key_format = :none
       server.channel.close
 
       # Clean up properly
       delete_queue
     end
 
-    context "with client started" do
+    context "with client started and configuration set to underscore results" do
+      before(:each) do
+        CarrotRpc.configuration.rpc_client_response_key_format = :underscore
+      end
+
+      after(:each) do
+        CarrotRpc.configuration.rpc_client_response_key_format = :none
+      end
       # lets
 
       let(:result) do

--- a/spec/carrot_rpc/rpc_server_spec.rb
+++ b/spec/carrot_rpc/rpc_server_spec.rb
@@ -98,8 +98,18 @@ RSpec.describe CarrotRpc::RpcServer do
         server.start
       end
 
-      it "parses the payload from json to hash and changes '-' to '_' in the keys" do
-        expect(client.create(payload)).to eq result
+      context "with client configured to underscore keys" do
+        before(:each) do
+          CarrotRpc.configuration.rpc_client_response_key_format = :underscore
+        end
+
+        after(:each) do
+          CarrotRpc.configuration.rpc_client_response_key_format = :none
+        end
+
+        it "parses the payload from json to hash and changes '-' to '_' in the keys" do
+          expect(client.create(payload)).to eq result
+        end
       end
     end
   end


### PR DESCRIPTION
Implementations of the RpcClient need to be flexible with the key formatter. Formatting can be set globally via `Configuration`, overridden via passing Configuration object upon initializing client, or redefine `response_key_formatter` `request_key_formatter` methods.