### PR TITLE
Request in thread-local variable, so it can be used for client request

### DIFF
--- a/lib/carrot_rpc.rb
+++ b/lib/carrot_rpc.rb
@@ -28,6 +28,7 @@ module CarrotRpc
   autoload :RpcClient
   autoload :RpcServer
   autoload :ServerRunner
+  autoload :Scrub
   autoload :TaggedLog
 
   class << self

--- a/lib/carrot_rpc.rb
+++ b/lib/carrot_rpc.rb
@@ -25,6 +25,7 @@ module CarrotRpc
   autoload :Exception
   autoload :Format
   autoload :HashExtensions
+  autoload :Reply
   autoload :RpcClient
   autoload :RpcServer
   autoload :ServerRunner

--- a/lib/carrot_rpc.rb
+++ b/lib/carrot_rpc.rb
@@ -23,6 +23,7 @@ module CarrotRpc
   autoload :Configuration
   autoload :Error
   autoload :Exception
+  autoload :Format
   autoload :HashExtensions
   autoload :RpcClient
   autoload :RpcServer

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -73,6 +73,15 @@ module CarrotRpc::CLI
     ) do |value|
       CarrotRpc.configuration.bunny = Bunny.new(value)
     end
+
+    option_parser.on(
+      " ",
+      "--thread-request VARIABLE",
+      "Copies the current request into VARIABLE Thread local variable, " \
+      "where it can be retrieved with `Thread.thread_variable_get(<VARIABLE>)`"
+    ) do |variable|
+      CarrotRpc.configuration.thread_request_variable = variable
+    end
   end
 
   def self.add_ruby_options(option_parser)

--- a/lib/carrot_rpc/configuration.rb
+++ b/lib/carrot_rpc/configuration.rb
@@ -2,7 +2,7 @@
 class CarrotRpc::Configuration
   attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :runloop_sleep, :autoload_rails, :bunny,
                 :before_request, :rpc_client_timeout, :rpc_client_response_key_format, :rpc_client_request_key_format,
-                :server_test_mode, :client_test_mode
+                :server_test_mode, :client_test_mode, :thread_request_variable
 
   # logfile - set logger to a file. overrides rails logger.
 
@@ -21,5 +21,6 @@ class CarrotRpc::Configuration
     @rpc_client_request_key_format = :none
     @client_test_mode = false
     @server_test_mode = false
+    @thread_request_variable = nil
   end # rubocop:enable Metrics/MethodLength
 end

--- a/lib/carrot_rpc/format.rb
+++ b/lib/carrot_rpc/format.rb
@@ -1,0 +1,23 @@
+# Used to format keys
+module CarrotRpc::Format
+  using CarrotRpc::HashExtensions
+
+  # Logic to process the renaming of keys in a hash.
+  # @param format [Symbol] :dasherize changes keys that have "_" to "-"
+  # @param format [Symbol] :underscore changes keys that have "-" to "_"
+  # @param format [Symbol] :skip, will not rename the keys
+  # @param data [Hash] data structure to be transformed
+  # @return [Hash] the transformed data
+  def self.keys(format, data)
+    case format
+    when :dasherize
+      data.rename_keys("_", "-")
+    when :underscore
+      data.rename_keys("-", "_")
+    when :none
+      data
+    else
+      data
+    end
+  end
+end

--- a/lib/carrot_rpc/reply.rb
+++ b/lib/carrot_rpc/reply.rb
@@ -1,0 +1,60 @@
+# Publishes properly formatted replies to consumed requests
+module CarrotRpc::Reply
+  private
+
+  def reply(properties:, response_message:)
+    payload = response_message.to_json
+
+    logger.debug "Publishing response: #{payload}"
+
+    @exchange.publish payload,
+                      correlation_id: properties.correlation_id,
+                      routing_key: properties.reply_to
+  end
+
+  # See http://www.jsonrpc.org/specification#error_object
+  def reply_error(error, properties:, request_message:)
+    response_message = { error: error, id: request_message[:id], jsonrpc: "2.0" }
+
+    reply properties: properties,
+          response_message: response_message
+  end
+
+  def reply_method_not_found(method:, properties:, request_message:)
+    error = CarrotRpc::Error.new code: CarrotRpc::Error::Code::METHOD_NOT_FOUND,
+                                 data: {
+                                   method: method
+                                 },
+                                 message: "Method not found"
+    logger.error(error)
+
+    reply_error error.serialized_message,
+                properties:      properties,
+                request_message: request_message
+  end
+
+  # See http://www.jsonrpc.org/specification#response_object
+  def reply_result(result, properties:, request_message:)
+    if result && result.is_a?(Hash) && result["errors"]
+      reply_result_with_errors(result, properties: properties, request_message: request_message)
+    else
+      reply_result_without_errors(result, properties: properties, request_message: request_message)
+    end
+  end
+
+  def reply_result_with_errors(result, properties:, request_message:)
+    scrubbed_result = result.merge(
+      "errors" => CarrotRpc::Scrub.errors(result.fetch("errors"))
+    )
+    reply_error({ code: 422, data: scrubbed_result, message: "JSONAPI error" },
+                properties: properties,
+                request_message: request_message)
+  end
+
+  def reply_result_without_errors(result, properties:, request_message:)
+    response_message = { id: request_message[:id], jsonrpc: "2.0", result: result }
+
+    reply properties: properties,
+          response_message: response_message
+  end
+end

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -133,7 +133,7 @@ class CarrotRpc::RpcServer
 
   def reply_result_with_errors(result, properties:, request_message:)
     scrubbed_result = result.merge(
-      "errors" => scrub_errors(result.fetch("errors"))
+      "errors" => CarrotRpc::Scrub.errors(result.fetch("errors"))
     )
     reply_error({ code: 422, data: scrubbed_result, message: "JSONAPI error" },
                 properties: properties,
@@ -145,20 +145,6 @@ class CarrotRpc::RpcServer
 
     reply properties: properties,
           response_message: response_message
-  end
-
-  # Removes `nil` values as JSONAPI spec expects unset keys not to be transmitted
-  def scrub_error(error)
-    error.reject { |_, value|
-      value.nil?
-    }
-  end
-
-  # Removes `nil` values as JSONAPI spec expects unset keys not to be transmitted
-  def scrub_errors(errors)
-    errors.map { |error|
-      scrub_error(error)
-    }
   end
 
   def thread_request(request_message:)

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -75,7 +75,11 @@ class CarrotRpc::RpcServer
   end
 
   def reply(properties:, response_message:)
-    @exchange.publish response_message.to_json,
+    payload = response_message.to_json
+
+    logger.debug "Publishing response: #{payload}"
+
+    @exchange.publish payload,
                       correlation_id: properties.correlation_id,
                       routing_key: properties.reply_to
   end
@@ -83,8 +87,6 @@ class CarrotRpc::RpcServer
   # See http://www.jsonrpc.org/specification#error_object
   def reply_error(error, properties:, request_message:)
     response_message = { error: error, id: request_message[:id], jsonrpc: "2.0" }
-
-    logger.debug "Publish error: #{error} to #{response_message}"
 
     reply properties: properties,
           response_message: response_message
@@ -123,8 +125,6 @@ class CarrotRpc::RpcServer
 
   def reply_result_without_errors(result, properties:, request_message:)
     response_message = { id: request_message[:id], jsonrpc: "2.0", result: result }
-
-    logger.debug "Publishing result: #{result} to #{response_message}"
 
     reply properties: properties,
           response_message: response_message

--- a/lib/carrot_rpc/rpc_server.rb
+++ b/lib/carrot_rpc/rpc_server.rb
@@ -8,6 +8,7 @@ class CarrotRpc::RpcServer
   # method_reciver => object that receives the method. can be a class or anything responding to send
 
   extend CarrotRpc::ClientServer
+  include CarrotRpc::Reply
 
   # Documentation advises not to share a channel connection. Create new channel for each server instance.
   def initialize(config: nil, block: true)
@@ -89,62 +90,6 @@ class CarrotRpc::RpcServer
     else
       :reply_method_not_found
     end
-  end
-
-  def reply(properties:, response_message:)
-    payload = response_message.to_json
-
-    logger.debug "Publishing response: #{payload}"
-
-    @exchange.publish payload,
-                      correlation_id: properties.correlation_id,
-                      routing_key: properties.reply_to
-  end
-
-  # See http://www.jsonrpc.org/specification#error_object
-  def reply_error(error, properties:, request_message:)
-    response_message = { error: error, id: request_message[:id], jsonrpc: "2.0" }
-
-    reply properties: properties,
-          response_message: response_message
-  end
-
-  def reply_method_not_found(method:, properties:, request_message:)
-    error = CarrotRpc::Error.new code: CarrotRpc::Error::Code::METHOD_NOT_FOUND,
-                                 data: {
-                                   method: method
-                                 },
-                                 message: "Method not found"
-    logger.error(error)
-
-    reply_error error.serialized_message,
-                properties:      properties,
-                request_message: request_message
-  end
-
-  # See http://www.jsonrpc.org/specification#response_object
-  def reply_result(result, properties:, request_message:)
-    if result && result.is_a?(Hash) && result["errors"]
-      reply_result_with_errors(result, properties: properties, request_message: request_message)
-    else
-      reply_result_without_errors(result, properties: properties, request_message: request_message)
-    end
-  end
-
-  def reply_result_with_errors(result, properties:, request_message:)
-    scrubbed_result = result.merge(
-      "errors" => CarrotRpc::Scrub.errors(result.fetch("errors"))
-    )
-    reply_error({ code: 422, data: scrubbed_result, message: "JSONAPI error" },
-                properties: properties,
-                request_message: request_message)
-  end
-
-  def reply_result_without_errors(result, properties:, request_message:)
-    response_message = { id: request_message[:id], jsonrpc: "2.0", result: result }
-
-    reply properties: properties,
-          response_message: response_message
   end
 
   def thread_request(request_message:)

--- a/lib/carrot_rpc/scrub.rb
+++ b/lib/carrot_rpc/scrub.rb
@@ -1,0 +1,16 @@
+# Removes `nil` valued keys from nested `Hash`es.
+module CarrotRpc::Scrub
+  # Removes `nil` values as JSONAPI spec expects unset keys not to be transmitted
+  def self.error(error)
+    error.reject { |_, value|
+      value.nil?
+    }
+  end
+
+  # Removes `nil` values as JSONAPI spec expects unset keys not to be transmitted
+  def self.errors(errors)
+    errors.map { |error|
+      error(error)
+    }
+  end
+end

--- a/lib/carrot_rpc/tagged_log.rb
+++ b/lib/carrot_rpc/tagged_log.rb
@@ -21,4 +21,10 @@ class CarrotRpc::TaggedLog
       logger.tagged(tags) { logger.send(level, msg || block.call) }
     end
   end
+
+  delegate :tagged, to: :logger
+
+  def with_correlation_id(correlation_id, &block)
+    tagged("correlation_id=#{correlation_id}", &block)
+  end
 end

--- a/spec/carrot_rpc/format_spec.rb
+++ b/spec/carrot_rpc/format_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe CarrotRpc::Format do
+  describe ".keys" do
+    context "with :dasherized" do
+      it "dasherizes the keys" do
+        params = { foo_bar: { "baz_zam" => 1 } }
+        res = described_class.keys :dasherize, params
+        expect(res).to eq("foo-bar" => { "baz-zam" => 1 })
+      end
+    end
+
+    context "with :underscore" do
+      it "underscores the keys" do
+        params = { "foo-bar" => { "baz-zam" => 1 } }
+        res = described_class.keys :underscore, params
+        expect(res).to eq("foo_bar" => { "baz_zam" => 1 })
+      end
+    end
+
+    context "with :none" do
+      it "skips key formatting" do
+        param_sets = [
+          { "foo-bar" => { "baz-zam" => 1 } },
+          { foo_bar: { "baz_zam" => 1 } },
+          { "foo_bar" => { "baz_zam" => 1 } }
+        ]
+
+        param_sets.each do |params|
+          res = described_class.keys :none, params
+          expect(res).to eq(params)
+        end
+      end
+    end
+  end
+end

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -232,33 +232,6 @@ RSpec.describe CarrotRpc::RpcClient do
     end
   end
 
-  describe "#format_keys" do
-    it "dasherizes the keys" do
-      params = { foo_bar: { "baz_zam" => 1 } }
-      res = described_class.format_keys :dasherize, params
-      expect(res).to eq("foo-bar" => { "baz-zam" => 1 })
-    end
-
-    it "underscores the keys" do
-      params = { "foo-bar" => { "baz-zam" => 1 } }
-      res = described_class.format_keys :underscore, params
-      expect(res).to eq("foo_bar" => { "baz_zam" => 1 })
-    end
-
-    it "skips key formatting for skip" do
-      param_sets = [
-        { "foo-bar" => { "baz-zam" => 1 } },
-        { foo_bar: { "baz_zam" => 1 } },
-        { "foo_bar" => { "baz_zam" => 1 } }
-      ]
-
-      param_sets.each do |params|
-        res = described_class.format_keys :none, params
-        expect(res).to eq(params)
-      end
-    end
-  end
-
   describe ".response_key_formatter" do
     before :each do
       CarrotRpc.configuration.rpc_client_response_key_format = :underscore
@@ -280,7 +253,7 @@ RSpec.describe CarrotRpc::RpcClient do
       subject { described_class.new(config) }
 
       it "overwrites the default config" do
-        expect(described_class).to receive(:format_keys).with(:dasherize, payload)
+        expect(CarrotRpc::Format).to receive(:keys).with(:dasherize, payload)
         subject.response_key_formatter(payload)
       end
     end
@@ -288,7 +261,7 @@ RSpec.describe CarrotRpc::RpcClient do
     context "without a config passed" do
       subject { described_class.new }
       it "uses the default config" do
-        expect(described_class).to receive(:format_keys).with(:underscore, payload)
+        expect(CarrotRpc::Format).to receive(:keys).with(:underscore, payload)
         subject.response_key_formatter(payload)
       end
     end
@@ -315,7 +288,7 @@ RSpec.describe CarrotRpc::RpcClient do
       subject { described_class.new(config) }
 
       it "overwrites the default config" do
-        expect(described_class).to receive(:format_keys).with(:dasherize, payload)
+        expect(CarrotRpc::Format).to receive(:keys).with(:dasherize, payload)
         subject.request_key_formatter(payload)
       end
     end
@@ -323,7 +296,7 @@ RSpec.describe CarrotRpc::RpcClient do
     context "without a config passed" do
       subject { described_class.new }
       it "uses the default config" do
-        expect(described_class).to receive(:format_keys).with(:underscore, payload)
+        expect(CarrotRpc::Format).to receive(:keys).with(:underscore, payload)
         subject.request_key_formatter(payload)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,12 @@ RSpec.configure do |config|
       bunny = Bunny.new
       bunny.start
       carrot_rpc_config.bunny = bunny
-      carrot_rpc_config.logger = Logger.new(log_file)
+      carrot_rpc_config.logger = CarrotRpc::TaggedLog.new(
+        logger: ActiveSupport::TaggedLogging.new(
+          Logger.new(log_file)
+        ),
+        tags: ["test"]
+      )
     end
   end
 


### PR DESCRIPTION
# Changelog
## Enhancements
* `carrot_rpc --thread-request VARIABLE` allows the request payload to be put in a Thread-local `VARIABLE, so that client that are invoked during an RPC server request can use parts of the request, most importantly, parts of "meta" in their own requests. This is needed to pass along ownership information for db_connection in Ecto 2.0.
* Tag the log with the correlation_id, as it can be filtered for then.
* Clarify whether a request or response is being published or received,
  so that server vs cient logging can be distinguished.