### PR TITLE
Remove busy-wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Usage: server [options]
 Process options:
     -d, --daemonize               run daemonized in the background (default: false)
         --pidfile PIDFILE         the pid filename
-    -s, --runloop_sleep VALUE     Configurable sleep time in the runloop
         --autoload_rails VALUE    loads rails env by default. Uses Rails Logger by default.
         --logfile VALUE           relative path and name for Log file. Overrides Rails logger.
         --loglevel VALUE          levels of loggin: DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN
@@ -98,7 +97,6 @@ CarrotRpc.configure do |config|
   # Don't use. Server implementation only. The values below are set via CLI:
   # config.logfile = nil
   # config.pidfile = nil
-  # config.runloop_sleep = 0
   # config.thread_request_variable = nil
 end
 ```

--- a/bin/carrot_rpc
+++ b/bin/carrot_rpc
@@ -14,6 +14,5 @@ end
 config = CarrotRpc.configuration
 config.bunny.start
 
-runner = CarrotRpc::ServerRunner.new(pidfile: config.pidfile, runloop_sleep: config.runloop_sleep,
-                                     daemonize: config.daemonize)
+runner = CarrotRpc::ServerRunner.new(pidfile: config.pidfile, daemonize: config.daemonize)
 runner.run!

--- a/lib/carrot_rpc/cli.rb
+++ b/lib/carrot_rpc/cli.rb
@@ -34,10 +34,6 @@ module CarrotRpc::CLI
       CarrotRpc.configuration.pidfile = value
     end
 
-    option_parser.on("-s", "--runloop_sleep VALUE", Float, "Configurable sleep time in the runloop") do |value|
-      CarrotRpc.configuration.runloop_sleep = value
-    end
-
     stm_msg = "runs servers with '_test' appended to queue names." \
               "Set Rails Rack env vars to 'test' when used in conjunction with '--autoload_rails'"
     option_parser.on(" ", "--server_test_mode", stm_msg) do

--- a/lib/carrot_rpc/configuration.rb
+++ b/lib/carrot_rpc/configuration.rb
@@ -1,6 +1,6 @@
 # Global configuration for {CarrotRpc}.  Access with {CarrotRpc.configuration}.
 class CarrotRpc::Configuration
-  attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :runloop_sleep, :autoload_rails, :bunny,
+  attr_accessor :logger, :logfile, :loglevel, :daemonize, :pidfile, :autoload_rails, :bunny,
                 :before_request, :rpc_client_timeout, :rpc_client_response_key_format, :rpc_client_request_key_format,
                 :server_test_mode, :client_test_mode, :thread_request_variable
 
@@ -12,7 +12,6 @@ class CarrotRpc::Configuration
     @logger = nil
     @daemonize = false
     @pidfile = nil
-    @runloop_sleep = 0
     @autoload_rails = true
     @bunny = nil
     @before_request = nil

--- a/lib/carrot_rpc/server_runner/signal.rb
+++ b/lib/carrot_rpc/server_runner/signal.rb
@@ -1,0 +1,60 @@
+# Stores a signal and allows for it to be waited on
+class CarrotRpc::ServerRunner::Signal
+  #
+  # Attributes
+  #
+
+  attr_reader :name
+
+  def initialize
+    self.reader, self.writer = IO.pipe
+  end
+
+  #
+  # Instance Methods
+  #
+
+  # Traps all {CarrotRpc::ServerRunner::Signals}.
+  #
+  # @return [void]
+  def trap
+    CarrotRpc::ServerRunner::Signals.trap do |name|
+      # @note can't log from a trap context: since Ruby 2.0 traps don't allow mutexes as it could lead to a dead lock,
+      #   so `logger.info` here would return "log writing failed. can't be called from trap context"
+      receive(name)
+    end
+  end
+
+  # Waits for a signal trapped by {#trap} to be received.
+  #
+  # @return [String]
+  def wait
+    loop do
+      # Wait {#receive}.  IO.select can wake up
+      read_ready, _write_ready, _error_ready = IO.select([reader])
+
+      next unless read_ready.include? reader
+
+      reader.read_nonblock(1)
+
+      break name
+    end
+  end
+
+  private
+
+  attr_writer :name
+
+  attr_accessor :reader,
+                :writer
+
+  # Sets `name` as the received signal
+  #
+  # @param name [String] name of the signal that was received from the trap
+  # @return [void]
+  def receive(name)
+    self.name = name
+    # any single byte works
+    writer.write_nonblock(".")
+  end
+end

--- a/lib/carrot_rpc/version.rb
+++ b/lib/carrot_rpc/version.rb
@@ -1,3 +1,3 @@
 module CarrotRpc
-  VERSION = "0.6.0".freeze
+  VERSION = "0.7.0".freeze
 end

--- a/spec/carrot_rpc/carrot_rpc_spec.rb
+++ b/spec/carrot_rpc/carrot_rpc_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe CarrotRpc do
 
   it "can use #configure to pass a block" do
     CarrotRpc.configure do |config|
-      config.runloop_sleep = 2000
+      config.loglevel = Logger::ERROR
     end
-    expect(CarrotRpc.configuration.runloop_sleep).to eq 2000
+    expect(CarrotRpc.configuration.loglevel).to eq Logger::ERROR
   end
 end

--- a/spec/carrot_rpc/cli_spec.rb
+++ b/spec/carrot_rpc/cli_spec.rb
@@ -5,19 +5,6 @@ require "carrot_rpc/cli"
 RSpec.describe CarrotRpc::CLI do
   subject { CarrotRpc::CLI }
 
-  describe "runloop sleep" do
-    before(:each) do
-      expect(CarrotRpc.configuration).to receive_message_chain("runloop_sleep=").with(10)
-    end
-
-    it "sets the sleep value with long switch" do
-      CarrotRpc::CLI.parse_options(["--runloop_sleep=10"])
-    end
-    it "sets the sleep value with short switch" do
-      CarrotRpc::CLI.parse_options(["-s", "10"])
-    end
-  end
-
   describe "daemonize" do
     before(:each) do
       expect(CarrotRpc.configuration).to receive("daemonize=").with(true)

--- a/spec/carrot_rpc/configuration_spec.rb
+++ b/spec/carrot_rpc/configuration_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe CarrotRpc::Configuration do
     expect(subject.pidfile).to eq nil
   end
 
-  it "defaults runloop sleep" do
-    expect(subject.runloop_sleep).to eq 0
-  end
-
   it "defaults to load rails" do
     expect(subject.autoload_rails).to eq true
   end


### PR DESCRIPTION
# Changelog
## Bug Fixes
* The `until quit` busy-wait loop consumes ~1 core for each instance of `carrot_rpc` as the default `sleep 0` does the minimal amount of sleep before waking up to check the boolean `quit`.  I've replaced it with an `IO.pipe` and `IO.select` that does not consume any resources while it waits. **NOTE: A Queue could not be used here because the MRI VM blocks use of Mutexes inside signal handlers to prevent deadlocks because the Mutex code is not-reentrant (i.e signal-interrupt-safe).  If a Queue is used the thread silently fails with an exception and the signal is ignored.**

## Incompatible Changes
* Removal of the busy-wait removes the `-s` (`--runloop_sleep`) option as it is no longer needed.