### PR TITLE
Update gemspec to allow Rails 5, but not 6.

### DIFF
--- a/carrot_rpc.gemspec
+++ b/carrot_rpc.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   # Production requirements
 
   # Common extensions from Rails
-  spec.add_dependency "activesupport", "~> 4.2"
+  spec.add_dependency "activesupport", ">= 4.2", "< 6.x"
   # The RabbitMQ library
   spec.add_dependency "bunny", "~> 2.2"
 


### PR DESCRIPTION
Allow rails 5 support. I have tested this in my environment (RpcClient only, however) and it works fine.