### PR TITLE
Allow the default RPC methods in CarrotRpc::RpcClient to be excluded

### DIFF
--- a/lib/carrot_rpc/client_actions.rb
+++ b/lib/carrot_rpc/client_actions.rb
@@ -31,4 +31,18 @@ module CarrotRpc::ClientActions
   def update(params)
     remote_call("update", params)
   end
+
+  # Let us define class methods in this included module. Used below.
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    # Remove the default methods above.
+    def no_default_methods
+      CarrotRpc::ClientActions.instance_methods.each do |instance_method|
+        undef_method instance_method
+      end
+    end
+  end
 end

--- a/spec/carrot_rpc/rpc_client_spec.rb
+++ b/spec/carrot_rpc/rpc_client_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe CarrotRpc::RpcClient do
     end
   end
 
+  describe "default methods" do
+    it "normally includes default methods" do
+      expect(client_class.instance_methods).to include(:show)
+    end
+
+    it "removes default methods when no_default_methods is called" do
+      client_class.no_default_methods
+      expect(client_class.instance_methods).not_to include(:show)
+    end
+  end
+
   describe "#remote_call" do
     before :each do
       CarrotRpc.configuration.rpc_client_request_key_format = :dasherize


### PR DESCRIPTION
Add a new class method `no_default_methods` which removes the methods added by CarrotRpc::ClientActions.

Example:

```
class Blah < CarrotRpc::RpcClient
  queue_name 'blah'
  no_default_methods
end
```