### PR TITLE
Logs and notifications for performance monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Changelog](#changelog)
   - [v1.1.0](#v110)
     - [Enhancements](#enhancements)
+    - [Bug Fixes](#bug-fixes)
   - [v1.0.0](#v100)
     - [Incompatible Changes](#incompatible-changes)
   - [v0.8.1](#v081)
@@ -12,42 +13,42 @@
   - [v0.8.0](#v080)
     - [Enhancements](#enhancements-2)
   - [v0.7.1](#v071)
-    - [Bug Fixes](#bug-fixes)
-  - [v0.7.0](#v070)
     - [Bug Fixes](#bug-fixes-1)
+  - [v0.7.0](#v070)
+    - [Bug Fixes](#bug-fixes-2)
     - [Incompatible Changes](#incompatible-changes-1)
   - [v0.6.0](#v060)
     - [Enhancements](#enhancements-3)
   - [v0.5.1](#v051)
-    - [Bug Fixes](#bug-fixes-2)
+    - [Bug Fixes](#bug-fixes-3)
   - [v0.5.0](#v050)
     - [Enhancements](#enhancements-4)
     - [Incompatible Changes](#incompatible-changes-2)
   - [v0.4.1](#v041)
-    - [Bug Fixes](#bug-fixes-3)
+    - [Bug Fixes](#bug-fixes-4)
   - [v0.4.0](#v040)
     - [Enhancements](#enhancements-5)
-    - [Bug Fixes](#bug-fixes-4)
+    - [Bug Fixes](#bug-fixes-5)
     - [Incompatible Changes](#incompatible-changes-3)
   - [v0.3.0](#v030)
     - [Enhancements](#enhancements-6)
-    - [Bug Fixes](#bug-fixes-5)
+    - [Bug Fixes](#bug-fixes-6)
   - [v0.2.3](#v023)
     - [Enhancements](#enhancements-7)
-    - [Bug Fixes](#bug-fixes-6)
+    - [Bug Fixes](#bug-fixes-7)
     - [Upgrading](#upgrading)
   - [v0.2.1](#v021)
-    - [Bug Fixes](#bug-fixes-7)
+    - [Bug Fixes](#bug-fixes-8)
   - [v0.2.0](#v020)
     - [Enhancements](#enhancements-8)
-    - [Bug Fixes](#bug-fixes-8)
+    - [Bug Fixes](#bug-fixes-9)
     - [Incompatible Changes](#incompatible-changes-4)
   - [v0.1.2](#v012)
     - [Enhancements](#enhancements-9)
-    - [Bug Fixes](#bug-fixes-9)
+    - [Bug Fixes](#bug-fixes-10)
   - [v0.1.1](#v011)
     - [Enhancements](#enhancements-10)
-    - [Bug Fixes](#bug-fixes-10)
+    - [Bug Fixes](#bug-fixes-11)
     - [Incompatible Changes](#incompatible-changes-5)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -62,6 +63,14 @@ All significant changes in the project are documented here.
   * `ActiveSupport::Notifications` to enable universal metrics gathering
     * `client.SERVER_QUEUE.remote_call` will include `correlation_id` of request
     * `server.SERVER_QUEUE.consume` will include `correlation_id` of request
+* [#56](https://github.com/C-S-D/carrot_rpc/pull/56) - [@KronicDeth](https://gitub.com/KronicDeth)
+  * Match client log tags to server log tags.
+    * Client tags will start with `client` as server tags start with `server`. 
+    * When available, it will have `server_queue=SERVER_QUEUE_NAME`.
+    * Finally, it will always have `correlation_id=CORRELATION_ID`.
+
+### Bug Fixes
+* [#56](https://github.com/C-S-D/carrot_rpc/pull/56) - `client.SERVER_QUEUE_NAME.remote_call` `ActiveSupport::Notification` was using the server queue object instead of name, so it interpolated as `#<...>`. - [@KronicDeth](https://gitub.com/KronicDeth)
 
 ## v1.0.0
 ### Incompatible Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,48 +3,50 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements)
   - [v1.0.0](#v100)
     - [Incompatible Changes](#incompatible-changes)
   - [v0.8.1](#v081)
-    - [Enhancements](#enhancements)
-  - [v0.8.0](#v080)
     - [Enhancements](#enhancements-1)
+  - [v0.8.0](#v080)
+    - [Enhancements](#enhancements-2)
   - [v0.7.1](#v071)
     - [Bug Fixes](#bug-fixes)
   - [v0.7.0](#v070)
     - [Bug Fixes](#bug-fixes-1)
     - [Incompatible Changes](#incompatible-changes-1)
   - [v0.6.0](#v060)
-    - [Enhancements](#enhancements-2)
+    - [Enhancements](#enhancements-3)
   - [v0.5.1](#v051)
     - [Bug Fixes](#bug-fixes-2)
   - [v0.5.0](#v050)
-    - [Enhancements](#enhancements-3)
+    - [Enhancements](#enhancements-4)
     - [Incompatible Changes](#incompatible-changes-2)
   - [v0.4.1](#v041)
     - [Bug Fixes](#bug-fixes-3)
   - [v0.4.0](#v040)
-    - [Enhancements](#enhancements-4)
+    - [Enhancements](#enhancements-5)
     - [Bug Fixes](#bug-fixes-4)
     - [Incompatible Changes](#incompatible-changes-3)
   - [v0.3.0](#v030)
-    - [Enhancements](#enhancements-5)
+    - [Enhancements](#enhancements-6)
     - [Bug Fixes](#bug-fixes-5)
   - [v0.2.3](#v023)
-    - [Enhancements](#enhancements-6)
+    - [Enhancements](#enhancements-7)
     - [Bug Fixes](#bug-fixes-6)
     - [Upgrading](#upgrading)
   - [v0.2.1](#v021)
     - [Bug Fixes](#bug-fixes-7)
   - [v0.2.0](#v020)
-    - [Enhancements](#enhancements-7)
+    - [Enhancements](#enhancements-8)
     - [Bug Fixes](#bug-fixes-8)
     - [Incompatible Changes](#incompatible-changes-4)
   - [v0.1.2](#v012)
-    - [Enhancements](#enhancements-8)
+    - [Enhancements](#enhancements-9)
     - [Bug Fixes](#bug-fixes-9)
   - [v0.1.1](#v011)
-    - [Enhancements](#enhancements-9)
+    - [Enhancements](#enhancements-10)
     - [Bug Fixes](#bug-fixes-10)
     - [Incompatible Changes](#incompatible-changes-5)
 
@@ -52,6 +54,14 @@
 
 # Changelog
 All significant changes in the project are documented here.
+
+## v1.1.0
+
+### Enhancements
+* [#55](https://github.com/C-S-D/carrot_rpc/pull/55) - [@shamil614](https://github.com/shamil614)
+  * `ActiveSupport::Notifications` to enable universal metrics gathering
+    * `client.SERVER_QUEUE.remote_call` will include `correlation_id` of request
+    * `server.SERVER_QUEUE.consume` will include `correlation_id` of request
 
 ## v1.0.0
 ### Incompatible Changes

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -79,7 +79,7 @@ class CarrotRpc::RpcClient
     correlation_id = SecureRandom.uuid
     extra = { correlation_id: correlation_id }
 
-    ActiveSupport::Notifications.instrument("client.#{server_queue}.remote_call", extra: extra) do
+    ActiveSupport::Notifications.instrument("client.#{server_queue.name}.remote_call", extra: extra) do
       logger.with_correlation_id(correlation_id) do
         params = self.class.before_request.call(params) if self.class.before_request
         publish(correlation_id: correlation_id, method: remote_method, params: request_key_formatter(params))

--- a/lib/carrot_rpc/rpc_client.rb
+++ b/lib/carrot_rpc/rpc_client.rb
@@ -76,16 +76,17 @@ class CarrotRpc::RpcClient
   def remote_call(remote_method, params)
     start
     subscribe
+    server_queue_name = server_queue.name
     correlation_id = SecureRandom.uuid
     extra = { correlation_id: correlation_id }
 
-    ActiveSupport::Notifications.instrument("client.#{server_queue.name}.remote_call", extra: extra) do
-      logger.with_correlation_id(correlation_id) do
+    ActiveSupport::Notifications.instrument("client.#{server_queue_name}.remote_call", extra: extra) {
+      logger.tagged("client", "server_queue=#{server_queue_name}", "correlation_id=#{correlation_id}") {
         params = self.class.before_request.call(params) if self.class.before_request
         publish(correlation_id: correlation_id, method: remote_method, params: request_key_formatter(params))
         wait_for_result(correlation_id)
-      end
-    end
+      }
+    }
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
@@ -147,15 +148,17 @@ class CarrotRpc::RpcClient
   private
 
   def consume(_delivery_info, properties, payload)
-    logger.with_correlation_id(properties[:correlation_id]) do
+    correlation_id = properties[:correlation_id]
+
+    logger.tagged("client", "correlation_id=#{correlation_id}") {
       logger.debug "Receiving response: #{payload}"
 
       response = JSON.parse(payload).with_indifferent_access
 
       result = parse_response(response)
       result = response_key_formatter(result).with_indifferent_access if result.is_a? Hash
-      @results[properties[:correlation_id]].push(result)
-    end
+      @results[correlation_id].push(result)
+    }
   end
 
   # Logic to find the data from the RPC response.

--- a/lib/carrot_rpc/version.rb
+++ b/lib/carrot_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module CarrotRpc
-  VERSION = "1.0.0".freeze
+  VERSION = "1.1.0".freeze
 end


### PR DESCRIPTION
# Changelog
## Enhancements
* Add #55 to changelog
* Bump version to `1.1.0`.
* Match client log tags to server log tags.
  * Client tags will start with `client` as server tags start with `server`. 
  * When available, it will have `server_queue=SERVER_QUEUE_NAME`.
  * Finally, it will always have `correlation_id=CORRELATION_ID`.

## Bug Fixes
* `client.SERVER_QUEUE_NAME.remote_call` `ActiveSupport::Notification` was using the server queue object instead of name, so it interpolated as `#<...>`.


