### PR TITLE
VPP-2700: Prevent rename_keys being called on Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,14 @@
 # Changelog
 All significant changes in the project are documented here.
 
+## v1.2.0
+
+### Enhancements
+* [#57](https://github.com/C-S-D/carrot_rpc/pull/57) - Regression test to prevent rename_keys being called on `String` - [@KronicDeth](https://gitub.com/KronicDeth)
+
+### Bug Fixes
+* [#57](https://github.com/C-S-D/carrot_rpc/pull/57) - Only rename key in values that are `Array`s or `Hash`es. - [@KronicDeth](https://gitub.com/KronicDeth)
+
 ## v1.1.0
 
 ### Enhancements

--- a/lib/carrot_rpc/hash_extensions.rb
+++ b/lib/carrot_rpc/hash_extensions.rb
@@ -1,17 +1,34 @@
 # Refine the Hash class with new methods and functionality.
 module CarrotRpc::HashExtensions
+  refine Array do
+    # Utility method to rename keys in a hash nested under array
+    #
+    # @param [String] find the text to look for in a keys
+    # @param [String] replace the text to replace the found text
+    # @return [Array] a new Array
+    def rename_keys(find, replace)
+      map { |element|
+        case element
+        when Array, Hash
+          element.rename_keys(find, replace)
+        else
+          element
+        end
+      }
+    end
+  end
+
   refine Hash do
     # Utility method to rename keys in a hash
     # @param [String] find the text to look for in a keys
     # @param [String] replace the text to replace the found text
     # @return [Hash] a new hash
-    def rename_keys(find, replace, new_hash = {}) # rubocop:disable Metrics/MethodLength
+    def rename_keys(find, replace, new_hash = {})
       each do |k, v|
         new_key = k.to_s.gsub(find, replace)
 
-        new_hash[new_key] = if v.is_a? Array
-                              v.map { |t| t.rename_keys(find, replace) }
-                            elsif v.is_a? Hash
+        new_hash[new_key] = case v
+                            when Array, Hash
                               v.rename_keys(find, replace)
                             else
                               v
@@ -19,6 +36,6 @@ module CarrotRpc::HashExtensions
       end
 
       new_hash
-    end # rubocop:enable Metrics/MethodLength
+    end
   end
 end

--- a/lib/carrot_rpc/version.rb
+++ b/lib/carrot_rpc/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module CarrotRpc
-  VERSION = "1.1.0".freeze
+  VERSION = "1.2.0".freeze
 end

--- a/spec/carrot_rpc/format_spec.rb
+++ b/spec/carrot_rpc/format_spec.rb
@@ -1,18 +1,20 @@
+require "spec_helper"
+
 RSpec.describe CarrotRpc::Format do
   describe ".keys" do
     context "with :dasherized" do
       it "dasherizes the keys" do
-        params = { foo_bar: { "baz_zam" => 1 } }
+        params = { foo_bar: { "baz_zam" => 1, "array" => ["string", { "nested_key" => "in array" }] } }
         res = described_class.keys :dasherize, params
-        expect(res).to eq("foo-bar" => { "baz-zam" => 1 })
+        expect(res).to eq("foo-bar" => { "baz-zam" => 1, "array" => ["string", { "nested-key" => "in array" }] })
       end
     end
 
     context "with :underscore" do
       it "underscores the keys" do
-        params = { "foo-bar" => { "baz-zam" => 1 } }
+        params = { foo_bar: { "baz_zam" => 1, "array" => ["string", { "nested-key" => "in array" }] } }
         res = described_class.keys :underscore, params
-        expect(res).to eq("foo_bar" => { "baz_zam" => 1 })
+        expect(res).to eq("foo_bar" => { "baz_zam" => 1, "array" => ["string", { "nested_key" => "in array" }] })
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each do |f|
 end
 
 require "carrot_rpc"
+require "active_support/tagged_logging"
 
 RSpec.configure do |config|
   config.before(:suite) do


### PR DESCRIPTION
# Changelog
## Enhancements
* Regression test to prevent rename_keys being called on `String`

## Bug Fixes
* Only rename key in values that are Array or Hashes.